### PR TITLE
feat: パスワード再設定（メール送信→更新）を実装

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,7 +1,36 @@
+# app/controllers/password_resets_controller.rb
 class PasswordResetsController < ApplicationController
-  def new
+  def new; end
+
+  def create
+    # 通常ログインユーザーのみ対象（provider が空）
+    if (user = User.find_by(email: params[:email], provider: nil))
+      user.generate_reset_token!
+      UserMailer.reset_password(user).deliver_later
+    end
+    redirect_to root_path, notice: "再設定用メールを送信しました（該当メールが存在する場合）"
   end
 
   def edit
+    @user = User.find_by(reset_password_token: params[:id]) # :id = token
+    redirect_to new_password_reset_path, alert: "トークンが無効です" unless @user&.reset_token_valid?
+  end
+
+  def update
+    @user = User.find_by(reset_password_token: params[:id])
+    return redirect_to new_password_reset_path, alert: "トークンが無効です" unless @user&.reset_token_valid?
+
+    # 通常ユーザーとして更新（外部ログインは対象外）
+    if @user.update(password_params.merge(provider: nil))
+      @user.clear_reset_token!
+      redirect_to new_session_path, notice: "パスワードを更新しました。ログインしてください"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+  def password_params
+    params.require(:user).permit(:password, :password_confirmation)
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,9 @@
+class UserMailer < ApplicationMailer
+  default from: "no-reply@example.com"
+
+  def reset_password(user)
+    @user = user
+    @url  = edit_password_reset_url(@user.reset_password_token) # トークンを path param で
+    mail to: @user.email, subject: "パスワード再設定のご案内"
+  end
+end

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,2 +1,12 @@
-<!-- app/views/password_resets/edit.html.erb -->
-<h1>Update password</h1>
+<h1>新しいパスワードを設定</h1>
+<%= form_with model: @user, url: password_reset_path(params[:id]), method: :patch, local: true do |f| %>
+  <div>
+    <%= f.label :password, '新しいパスワード' %>
+    <%= f.password_field :password, required: true, minlength: 6 %>
+  </div>
+  <div>
+    <%= f.label :password_confirmation, 'パスワード（確認）' %>
+    <%= f.password_field :password_confirmation, required: true, minlength: 6 %>
+  </div>
+  <%= f.submit '更新する' %>
+<% end %>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,1 +1,8 @@
-<h1>Password reset</h1>
+<h1>パスワード再設定</h1>
+<%= form_with url: password_resets_path, method: :post, local: true do |f| %>
+  <div>
+    <label>登録メールアドレス</label>
+    <%= email_field_tag :email, params[:email], required: true, autocomplete: 'email' %>
+  </div>
+  <%= submit_tag 'メールを送信' %>
+<% end %>

--- a/app/views/user_mailer/reset_password.html.erb
+++ b/app/views/user_mailer/reset_password.html.erb
@@ -1,0 +1,3 @@
+<!-- app/views/user_mailer/reset_password.html.erb (HTML) -->
+<p>以下のボタンからパスワードを再設定してください（30分以内有効）</p>
+<p><a href="<%= @url %>">パスワードを再設定する</a></p>

--- a/app/views/user_mailer/reset_password.text.erb
+++ b/app/views/user_mailer/reset_password.text.erb
@@ -1,0 +1,3 @@
+<!-- app/views/user_mailer/reset_password.text.erb (プレーン) -->
+以下のURLからパスワードを再設定してください（30分以内有効）
+<%= @url %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ module RailsLearning
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
+    config.active_job.queue_adapter = :async # or :sidekiq 等
 
     config.generators do |g|
       g.test_framework :rspec,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Set localhost to be used by links generated in mailer templates.
+  config.action_mailer.delivery_method = :test
+  config.action_mailer.perform_deliveries = false
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,20 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  # ENV[...]はRenderのダッシュボード側で設定する
+  config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST") }
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: ENV["SMTP_ADDRESS"],
+    port: ENV.fetch("SMTP_PORT", 587),
+    domain: ENV["SMTP_DOMAIN"],
+    user_name: ENV["SMTP_USERNAME"],
+    password: ENV["SMTP_PASSWORD"],
+    authentication: :login,
+    enable_starttls_auto: true
+  }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
 
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "example.com" }
+  config.active_job.queue_adapter = :test
+  config.action_mailer.perform_deliveries = true
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,3 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer_mailer
+class UserMailerPreview < ActionMailer::Preview
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,6 +32,8 @@ RSpec.configure do |config|
 
   # --- FactoryBot を短縮呼び出し（create, build など）
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
+  config.include ActiveJob::TestHelper
 end
 
 # --- shoulda-matchers（モデル/バリデーションの定番: 任意）

--- a/spec/requests/password_resets_spec.rb
+++ b/spec/requests/password_resets_spec.rb
@@ -1,19 +1,99 @@
 # spec/requests/password_resets_spec.rb
 require 'rails_helper'
 
-RSpec.describe 'PasswordResets', type: :request do
-  describe 'GET /password_resets/new' do
-    it '200 が返る' do
-      get new_password_reset_path
-      expect(response).to have_http_status(:ok)
+RSpec.describe "PasswordResets", type: :request do
+  let!(:user) { create(:user, email: "pw@example.com", password: "secret123", password_confirmation: "secret123") }
+  let!(:oauth_user) { create(:google_user, email: "oauth@example.com") } # factory 側で provider/uid を持つ
+
+  before { ActionMailer::Base.deliveries.clear }
+
+  describe "POST /password_resets" do
+    it "通常ユーザーならトークンを発行し、メール（test配信）を1通積む" do
+      perform_enqueued_jobs do
+        post password_resets_path, params: { email: user.email }
+      end
+
+      user.reload
+      expect(user.reset_password_token).to be_present
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "外部ログインユーザーは何もしない（トークン発行もdeliveries増えない）" do
+      perform_enqueued_jobs do
+        post password_resets_path, params: { email: oauth_user.email }
+      end
+
+      oauth_user.reload
+      expect(oauth_user.reset_password_token).to be_nil
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "存在しないメールでも同じレスポンス（情報漏えい防止）" do
+      post password_resets_path, params: { email: "nobody@example.com" }
+      expect(response).to redirect_to(root_path)
+      expect(ActionMailer::Base.deliveries).to be_empty
     end
   end
 
-  describe 'GET /password_resets/:token/edit' do
-    it '（仮）ダミートークンでも 200 が返る' do
-      # 実装後は有効なトークンで検証する
-      get edit_password_reset_path('dummy-token')
+  describe "GET /password_resets/:token/edit" do
+    it "有効トークンなら編集画面を表示できる" do
+      post password_resets_path, params: { email: user.email }
+      token = user.reload.reset_password_token
+      get edit_password_reset_path(token)
       expect(response).to have_http_status(:ok)
+    end
+
+    it "期限切れトークンは編集画面に入れない" do
+      post password_resets_path, params: { email: user.email }
+      token = user.reload.reset_password_token
+      travel_to 31.minutes.from_now do
+        get edit_password_reset_path(token)
+        expect(response).to redirect_to(new_password_reset_path)
+        follow_redirect!
+        expect(response.body).to include("トークンが無効です").or include("無効") # 文言合わせ
+      end
+    end
+  end
+
+  describe "PATCH /password_resets/:token" do
+    before do
+      post password_resets_path, params: { email: user.email }
+      @token = user.reload.reset_password_token
+    end
+
+    it "有効トークンならパスワードを更新し、トークンはクリアされる" do
+      patch password_reset_path(@token), params: {
+        user: { password: "newsecret", password_confirmation: "newsecret" }
+      }
+      expect(response).to redirect_to(new_session_path)
+
+      user.reload
+      expect(user.authenticate("newsecret")).to be_truthy
+      expect(user.reset_password_token).to be_nil
+      expect(user.reset_password_sent_at).to be_nil
+    end
+
+    it "バリデーション NG なら 422 で再表示" do
+      patch password_reset_path(@token), params: {
+        user: { password: "short", password_confirmation: "mismatch" }
+      }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("エラー").or include("error")
+      # トークンはまだ生きている（再送信・やり直し可能）
+      expect(user.reload.reset_password_token).to eq(@token)
+    end
+
+    it "期限切れなら更新できない" do
+      travel_to 31.minutes.from_now do
+        patch password_reset_path(@token), params: {
+          user: { password: "newsecret", password_confirmation: "newsecret" }
+        }
+        expect(response).to redirect_to(new_password_reset_path)
+        # 期限切れでも通常はトークンは残ったまま（UXにより設計可）
+        expect(user.reload.reset_password_token).to eq(@token)
+      end
     end
   end
 end


### PR DESCRIPTION
### 概要
パスワード再設定機能を実装した。

**作業内容**

- UserMailerの作成と編集
- app/controllers/password_resets_controller.rb の編集
- 対応するviewファイルの編集
- 開発環境下と本番環境下のメール配信設定
- 非同期通信の設定
- セキュリティ対策
- RSpecファイルの編集