### PR TITLE
feat: 本番用のパスワード再設定機能を実装

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV.fetch("MAIL_FROM", "railslearning.developer0919@gmail.com")
   layout "mailer"
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,4 @@
 class UserMailer < ApplicationMailer
-  default from: "no-reply@example.com"
-
   def reset_password(user)
     @user = user
     @url  = edit_password_reset_url(@user.reset_password_token) # トークンを path param で

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
 
   # Set host to be used by links generated in mailer templates.
   # ENV[...]はRenderのダッシュボード側で設定する
-  config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST") }
+  config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST"), protocol: "https" }
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp


### PR DESCRIPTION
### 概要
本番用のパスワード再設定機能を実装した。

**作業内容**

- Gmail SMTP を導入、設定を行なった
- Environment Variablesに必要事項を入力した
- Mailerの設定を一部変更した