### PR TITLE
feat(pre_codes/pagination): Kaminari を導入し index にページネーションを実装

### DIFF
--- a/app/controllers/pre_codes_controller.rb
+++ b/app/controllers/pre_codes_controller.rb
@@ -7,6 +7,7 @@ class PreCodesController < ApplicationController
     @pre_codes = current_user.pre_codes
                              .order(id: :desc)
                              .page(params[:page])
+                             .per(5)
   end
 
   # GET /pre_codes/:id

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,10 @@
+<% base = "px-3 py-1 rounded ring-1 ring-slate-300 hover:bg-slate-50" %>
+<% disabled = "px-3 py-1 rounded ring-1 ring-slate-200 text-slate-300 cursor-default" %>
+
+<% if current_page.first? %>
+  <span class="<%= disabled %>" aria-disabled="true">
+    <%= t("views.pagination.first") %>
+  </span>
+<% else %>
+  <%= link_to t("views.pagination.first"), url, class: base %>
+<% end %>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,1 @@
+<span class="px-2 text-slate-400"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,10 @@
+<% base = "px-3 py-1 rounded ring-1 ring-slate-300 hover:bg-slate-50" %>
+<% disabled = "px-3 py-1 rounded ring-1 ring-slate-200 text-slate-300 cursor-default" %>
+
+<% if current_page.last? %>
+  <span class="<%= disabled %>" aria-disabled="true">
+    <%= t("views.pagination.last") %>
+  </span>
+<% else %>
+  <%= link_to t("views.pagination.last"), url, class: base %>
+<% end %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,10 @@
+<% base = "px-3 py-1 rounded ring-1 ring-slate-300 hover:bg-slate-50" %>
+<% disabled = "px-3 py-1 rounded ring-1 ring-slate-200 text-slate-300 cursor-default" %>
+
+<% if current_page.last? %>
+  <span class="<%= disabled %>" aria-disabled="true">
+    <%= t("views.pagination.next") %>
+  </span>
+<% else %>
+  <%= link_to t("views.pagination.next"), url, rel: "next", class: base %>
+<% end %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,8 @@
+<!-- app/views/kaminari/_page.html.erb -->
+<%# active なら強調 %>
+<%= link_to page, url, rel: page.rel,
+  class: [
+    "px-3 py-1 rounded",
+    (page.current? ? "bg-slate-900 text-white" : "ring-1 ring-slate-300 hover:bg-slate-50")
+  ].join(" ")
+%>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,20 @@
+<%# app/views/kaminari/_paginator.html.erb %>
+<%= paginator.render do %>
+  <nav class="inline-flex items-center gap-1" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag  unless current_page.first? %>
+
+    <% each_page do |page| %>
+      <% if page.display_tag? %>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? %>
+        <%= gap_tag %>
+      <% end %>
+    <% end %>
+
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,10 @@
+<% base = "px-3 py-1 rounded ring-1 ring-slate-300 hover:bg-slate-50" %>
+<% disabled = "px-3 py-1 rounded ring-1 ring-slate-200 text-slate-300 cursor-default" %>
+
+<% if current_page.first? %>
+  <span class="<%= disabled %>" aria-disabled="true">
+    <%= t("views.pagination.previous") %>
+  </span>
+<% else %>
+  <%= link_to t("views.pagination.previous"), url, rel: "prev", class: base %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module RailsLearning
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
     config.active_job.queue_adapter = :inline
+    config.i18n.default_locale = :ja
 
     config.generators do |g|
       g.test_framework :rspec,

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,14 +1,7 @@
-# frozen_string_literal: true
-
+# config/initializers/kaminari_config.rb
 Kaminari.configure do |config|
-  # config.default_per_page = 25
-  # config.max_per_page = nil
-  # config.window = 4
-  # config.outer_window = 0
-  # config.left = 0
-  # config.right = 0
-  # config.page_method_name = :page
-  # config.param_name = :page
-  # config.max_pages = nil
-  # config.params_on_first_page = false
+  config.default_per_page = 10   # 既定件数
+  config.window = 1              # 現在ページ左右に出すページ数
+  config.outer_window = 1        # 先頭/末尾側に出すページ数
+  # config.param_name = :page    # パラメータ名を変えたいとき
 end

--- a/config/locales/kaminari.ja.yml
+++ b/config/locales/kaminari.ja.yml
@@ -1,0 +1,7 @@
+ja:
+  views:
+    pagination:
+      first: "« 最初へ"
+      last:  "最後へ »"
+      previous: "‹ 前へ"
+      next: "次へ ›"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,12 @@ Rails.application.routes.draw do
   resources :password_resets, only: %i[new create edit update]  # パス再設定用
 
   # PreCode機能
-  resources :pre_codes
+  concern :paginatable do
+    # /pre_codes/page/2 → index の2ページ目に到達
+    get "(page/:page)", action: :index, on: :collection, as: "", constraints: { page: /\d+/ }
+  end
+
+  resources :pre_codes, concerns: :paginatable
   # 将来的に使うルート
   # resources :code_libraries, only: %i[index show]
   # resources :likes,        only: %i[create destroy]

--- a/spec/requests/pre_codes_spec.rb
+++ b/spec/requests/pre_codes_spec.rb
@@ -51,4 +51,23 @@ RSpec.describe "PreCodes", type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
     end
   end
+
+  describe "ページネーション" do
+    before { sign_in(user) }
+
+    it "index はページネーションされる" do
+      # 1ページ=25件がデフォルトなので、26件作って2ページ目を発生させる
+      create_list(:pre_code, 26, user: user, title: "p")
+
+      # 1ページ目には「次へ」が出るはず
+      get pre_codes_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('rel="next"')   # Kaminari の next リンク
+
+      # 2ページ目には「前へ」が出るはず
+      get pre_codes_path(page: 2)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('rel="prev"')   # Kaminari の prev リンク
+    end
+  end
 end


### PR DESCRIPTION
### 概要
Kaminari を導入し、PreCodeコントローラーの index にページネーションを実装した。

**作業内容**

- kaminariのビューテンプレートファイルを作成し、編集した
- PreCodeコントローラーの index アクションにページネーションを実装した
- app/views/pre_codes/index.html.erb の末尾にページャを導入した
- config/initializers/kaminari_config.rb で詳細設定を行った
- config/routes.rb で、ルートに関する設定を行った
- i18n ファイルの作成と編集