### PR TITLE
feat: PreCode機能に認証・認可ガードを追加（未ログイン時リダイレクト／所有者以外は404）

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,11 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
   helper_method :current_user, :logged_in?
 
+  rescue_from ActiveRecord::RecordNotFound do
+    # 本番は既定で 404 HTML を返します。開発でも同じにしたいなら:
+    render file: Rails.public_path.join("404.html"), status: :not_found, layout: false
+  end
+
   private
 
   def current_user


### PR DESCRIPTION
### 概要
PreCode機能に認証・認可ガードを追加した（未ログイン時リダイレクト／所有者以外は404）。

**作業内容**

- before_actionを使った未ログインガード（認証）機能を実装した
- private 内で、current_user のスコープから find する所有者チェック（認可）機能を実装した
- ApplicationController に、ActiveRecord::RecordNotFound が起こった時に自動で404が表示される設定を作成した