### PR TITLE
feat(code_library): Ransackで検索/並び替えを追加し、Kaminariと連携してページネーション対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,9 @@ gem "omniauth-github"
 # ページネーション
 gem "kaminari"
 
+# 検索機能
+gem "ransack"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,6 +315,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.0)
+    ransack (4.3.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
@@ -478,6 +482,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2, >= 8.0.2.1)
+  ransack
   rspec-rails
   rubocop-rails-omakase
   selenium-webdriver

--- a/app/controllers/code_libraries_controller.rb
+++ b/app/controllers/code_libraries_controller.rb
@@ -2,21 +2,30 @@ class CodeLibrariesController < ApplicationController
   before_action :set_pre_code, only: :show
 
   def index
-    # params: q(キーワード), sort(popular|used), page
-    scope = PreCode.all
-    scope = scope.except_user(current_user.id) if current_user # 自分の投稿を除外
-    scope = scope.keyword(params[:q])
+    base = PreCode.except_user(current_user&.id)
+    @q = base.ransack(params[:q])
 
-    case params[:sort]
-    when "used" then scope = scope.most_used
-    else             scope = scope.popular # デフォルト: 人気順
-    end
+    # 検索結果
+    rel = @q.result
 
-    @pre_codes = scope.includes(:user).page(params[:page])
+    # ソートキー（popular / used / newest）。デフォルト popular
+    sort_key = params[:sort].presence || "popular"
+
+    rel =
+      case sort_key
+      when "used"
+        rel.order(use_count: :desc).order(like_count: :desc).order(created_at: :desc)
+      when "newest"
+        rel.order(created_at: :desc).order(like_count: :desc).order(use_count: :desc)
+      else # "popular"
+        rel.order(like_count: :desc).order(use_count: :desc).order(created_at: :desc)
+      end
+
+    @pre_codes = rel.includes(:user).page(params[:page])
   end
 
   def show
-    if current_user && @pre_code.user_id == current_user.id
+    if logged_in? && @pre_code.user_id == current_user.id
       redirect_to pre_codes_path, alert: "自分のデータです" and return
     end
   end

--- a/app/models/pre_code.rb
+++ b/app/models/pre_code.rb
@@ -15,8 +15,13 @@ class PreCode < ApplicationRecord
   scope :except_user, ->(user_id) { user_id.present? ? where.not(user_id: user_id) : all }
   scope :popular,     -> { order(like_count: :desc, id: :desc) }
   scope :most_used,   -> { order(use_count: :desc,   id: :desc) }
-  scope :keyword,     ->(kw) {
-    next all if kw.blank?
-    where("title ILIKE :q OR description ILIKE :q", q: "%#{kw}%")
-  }
+
+  # === Ransack 4 (Rails 7+) 許可リスト ===
+  def self.ransackable_attributes(_auth = nil)
+    %w[title description like_count use_count created_at user_id]
+  end
+
+  def self.ransackable_associations(_auth = nil)
+    %w[user]
+  end
 end

--- a/app/views/code_libraries/index.html.erb
+++ b/app/views/code_libraries/index.html.erb
@@ -1,25 +1,33 @@
-<%# app/views/code_libraries/index.html.erb %>
+<!-- app/views/code_libraries/index.html.erb -->
 <% content_for :title, "コードライブラリ" %>
 
-<!-- 見出し → フォームを縦に並べる -->
 <div class="mb-4 space-y-3">
+  <!-- 見出し -->
   <div>
     <h1 class="text-xl font-semibold"><%= yield :title %></h1>
   </div>
 
+  <!-- 検索フォーム（Ransack） -->
   <div>
-    <%= form_with url: code_libraries_path, method: :get, class: "flex gap-2" do %>
-      <%= text_field_tag :q, params[:q], placeholder: "キーワード",
+    <%= search_form_for @q, url: code_libraries_path, method: :get, html: { class: "flex gap-2" } do |f| %>
+      <%= f.search_field :title_or_description_cont,
+            value: @q.title_or_description_cont,
+            placeholder: "キーワード",
             class: "px-3 py-2 rounded ring-1 ring-slate-300 w-64 md:w-80" %>
+
       <%= select_tag :sort,
-            options_for_select([["人気順","popular"],["利用数順","used"]], params[:sort]),
+            options_for_select(
+              [["人気順", "popular"], ["利用数順", "used"], ["新着順", "newest"]],
+              params[:sort].presence || "popular"
+            ),
             class: "px-3 py-2 rounded ring-1 ring-slate-300" %>
-      <%= submit_tag "検索", class: "px-3 py-2 rounded bg-slate-900 text-white" %>
+
+      <%= f.submit "検索", class: "px-3 py-2 rounded bg-slate-900 text-white" %>
     <% end %>
   </div>
 </div>
 
-<%# ---- 一覧 ---- %>
+<!-- 一覧 -->
 <% if @pre_codes.blank? %>
   <p class="text-slate-500">該当するデータがありません。</p>
 <% else %>
@@ -32,9 +40,10 @@
             <p class="text-sm text-slate-500 mt-1"><%= truncate(pc.description, length: 100) %></p>
           </div>
           <div class="text-sm text-slate-500">
-            👍 <%= pc.like_count %>・🧰 <%= pc.use_count %>
+            👍 <%= pc.like_count %> ・ 🧰 <%= pc.use_count %>
           </div>
         </div>
+
         <div class="mt-3">
           <% current_like = logged_in? ? pc.likes.find_by(user_id: current_user.id) : nil %>
           <%= render "actions", pre_code: pc, current_like: current_like %>
@@ -43,5 +52,8 @@
     <% end %>
   </ul>
 
-  <div class="mt-6"><%= paginate @pre_codes %></div>
+  <!-- ページネーション（検索条件を保持して遷移） -->
+  <div class="mt-6">
+    <%= paginate @pre_codes, params: request.query_parameters %>
+  </div>
 <% end %>

--- a/spec/requests/code_libraries_spec.rb
+++ b/spec/requests/code_libraries_spec.rb
@@ -2,11 +2,13 @@
 require "rails_helper"
 
 RSpec.describe "CodeLibraries", type: :request do
-  let(:me)         { create(:user, password: "secret123", password_confirmation: "secret123") }
-  let(:other)      { create(:user) }
-  let!(:mine)      { create(:pre_code, user: me,   title: "my code",  description: "mine") }
-  let!(:other_a)   { create(:pre_code, user: other, title: "alpha",   description: "foo bar") }
-  let!(:other_b)   { create(:pre_code, user: other, title: "bravo",   description: "baz buzz") }
+  let(:me)    { create(:user, password: "secret123", password_confirmation: "secret123") }
+  let(:other) { create(:user) }
+
+  # 基本データ
+  let!(:mine)    { create(:pre_code, user: me,    title: "my code", description: "mine") }
+  let!(:other_a) { create(:pre_code, user: other, title: "alpha",  description: "foo bar") }
+  let!(:other_b) { create(:pre_code, user: other, title: "bravo",  description: "baz buzz") }
 
   describe "GET /code_libraries (index)" do
     it "ゲストでも200が返り、一覧が表示される" do
@@ -22,38 +24,44 @@ RSpec.describe "CodeLibraries", type: :request do
       expect(response.body).not_to include(mine.title)
     end
 
-    it "キーワード検索が効く（title/description）" do
-      # other_a.description に "foo" が入っている
-      get code_libraries_path, params: { q: "foo" }
+    it "キーワード検索が効く（title/description の部分一致）" do
+      # Ransack 形式のパラメータに合わせる
+      get code_libraries_path, params: { q: { title_or_description_cont: "foo" } }
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include(other_a.title)
+      expect(response.body).to include(other_a.title)   # "foo" を含む説明
       expect(response.body).not_to include(other_b.title)
     end
 
     it "人気順（like_count）と利用数順（use_count）で並び替えできる" do
       users = create_list(:user, 5)
-      # like: other_b を3、other_a を1
+
+      # いいね: other_b を3、other_a を1
       users.first(3).each { |u| create(:like, user: u, pre_code: other_b) }
       create(:like, user: users[3], pre_code: other_a)
 
-      # used: other_a を2、other_b を1
+      # 利用: other_a を2、other_b を1
       create(:used_code, user: users[0], pre_code: other_a)
       create(:used_code, user: users[1], pre_code: other_a)
       create(:used_code, user: users[2], pre_code: other_b)
 
-      # popular（like多い順） → other_b が先頭
+      # デフォルト/人気順 → other_b が先頭
       get code_libraries_path, params: { sort: "popular" }
       expect(response.body.index(other_b.title)).to be < response.body.index(other_a.title)
 
-      # used（use_count多い順） → other_a が先頭
+      # 利用数順 → other_a が先頭
       get code_libraries_path, params: { sort: "used" }
       expect(response.body.index(other_a.title)).to be < response.body.index(other_b.title)
+
+      # 新着順（念のため） → より新しい方が先頭
+      newest = create(:pre_code, user: other, title: "newbie", created_at: 1.minute.from_now)
+      get code_libraries_path, params: { sort: "newest" }
+      expect(response.body.index("newbie")).to be < response.body.index(other_a.title)
     end
 
-    it "ページネーション用の rel=\"next\" が含まれる（多件データ）" do
-      create_list(:pre_code, 30, user: other)
+    it "ページネーションのリンク（rel=\"next\" or rel=\"prev\"）が出る（多件時）" do
+      # Kaminari デフォルト 25 件想定 → 26 件で2ページ目が発生
+      create_list(:pre_code, 26, user: other)
       get code_libraries_path
-      # kaminari の next リンク（_paginator の rel 属性）
       expect(response.body).to include('rel="next"').or include('rel="prev"')
     end
   end
@@ -65,7 +73,7 @@ RSpec.describe "CodeLibraries", type: :request do
       expect(response.body).to include(other_a.title)
     end
 
-    it "自分の投稿へは pre_codes へリダイレクトされる" do
+    it "自分の投稿へは /pre_codes へリダイレクトされる" do
       sign_in(me)
       get code_library_path(mine)
       expect(response).to redirect_to(pre_codes_path)


### PR DESCRIPTION
### 概要
Ransackで検索/並び替えを追加し、Kaminariと連携してページネーション対応を行った。

**作業内容**

- Gem（gem "ransack"）を導入した
- モデルに Ransack の許可をするコードを設定
- CodeLibrariesController の index アクションをransack用に差し替えた
- 対応するビューファイルの検索フォームをRansack化した
- RSpecファイルをRansackように修正した
