### PR TITLE
feat(editor): Stimulusコントローラで実行/初期データ読込/テーマ保存を実装（CodeMirror+axios、CSR…

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,7 @@
-// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+// app/javascript/application.js
 import "@hotwired/turbo-rails"
 import "controllers"
+import axios from "axios"
+
+const token = document.querySelector('meta[name="csrf-token"]')?.content
+if (token) axios.defaults.headers.common["X-CSRF-Token"] = token

--- a/app/javascript/controllers/editor_controller.js
+++ b/app/javascript/controllers/editor_controller.js
@@ -1,0 +1,102 @@
+// app/javascript/controllers/editor_controller.js
+import { Controller } from "@hotwired/stimulus"
+import axios from "axios"
+
+import { EditorState, Compartment } from "@codemirror/state"
+import { EditorView, lineNumbers } from "@codemirror/view"
+import { oneDark } from "@codemirror/theme-one-dark"
+
+// CodeMirror 6 共通言語レイヤ
+import { StreamLanguage, syntaxHighlighting, HighlightStyle } from "@codemirror/language"
+
+// Ruby レガシーモード（CM5） → CM6 で包む
+import { ruby } from "@codemirror/legacy-modes/mode/ruby"
+
+// ハイライト定義（色とタグ）
+import { tags as t } from "@lezer/highlight"
+
+// -- ここからはあなたの既存ロジックそのまま --
+const rubyHighlight = HighlightStyle.define([
+  { tag: t.comment,                       color: "#16a34a" },
+  { tag: [t.string, t.special(t.string)], color: "#2563eb" },
+  { tag: t.number,                        color: "#d97706" },
+  { tag: [t.keyword, t.controlKeyword],   color: "#9333ea", fontWeight: "600" },
+  { tag: [t.atom, t.regexp],              color: "#0ea5e9" },
+  { tag: t.function(t.variableName),      color: "#0284c7" },
+])
+
+const rubyLang = StreamLanguage.define(ruby)
+
+const KEY = { code: "editor:code", theme: "editor:theme" }
+const SAVE_DELAY = 50
+
+export default class extends Controller {
+  static targets = ["mount", "output", "select"]
+
+  connect() {
+    this.theme = localStorage.getItem(KEY.theme) === "dark" ? "dark" : "light"
+    this.themeCompartment = new Compartment()
+
+    this.state = EditorState.create({
+      doc: localStorage.getItem(KEY.code) || "",
+      extensions: [
+        lineNumbers(),
+        rubyLang,
+        syntaxHighlighting(rubyHighlight),
+        EditorView.updateListener.of(v => {
+          if (!v.docChanged) return
+          clearTimeout(this._saveTimer)
+          this._saveTimer = setTimeout(() => {
+            localStorage.setItem(KEY.code, v.state.doc.toString())
+          }, SAVE_DELAY)
+        }),
+        this.themeCompartment.of(this.theme === "dark" ? oneDark : []),
+      ],
+    })
+
+    this.view = new EditorView({ state: this.state, parent: this.mountTarget })
+  }
+
+  disconnect() { this.view?.destroy() }
+
+  async run(event) {
+    const btn = event?.currentTarget || this.element.querySelector('[data-action*="editor#run"]')
+    btn?.setAttribute("disabled", "disabled")
+    this.outputTarget.textContent = "実行中…"
+    try {
+      const code = this.view.state.doc.toString()
+      const res  = await axios.post("/editor", { code })
+      const { status, stdout, stderr, time, memory } = res.data
+      this.outputTarget.textContent =
+        `Status: ${status}\n` +
+        (stdout ? `\n=== stdout ===\n${stdout}` : "") +
+        (stderr ? `\n=== stderr ===\n${stderr}` : "") +
+        (time || memory ? `\n(time: ${time ?? "-"}s, mem: ${memory ?? "-"}KB)` : "")
+    } catch (e) {
+      this.outputTarget.textContent = `Error: ${e?.response?.data?.error || e}`
+    } finally {
+      btn?.removeAttribute("disabled")
+    }
+  }
+
+  async changeSelect() {
+    const id = this.selectTarget.value
+    if (!id) return
+    try {
+      const res  = await axios.get(`/pre_codes/${id}/body`)
+      const body = res.data?.body || ""
+      this.view.dispatch({ changes: { from: 0, to: this.view.state.doc.length, insert: body } })
+      localStorage.setItem(KEY.code, body)
+    } catch (e) {
+      this.outputTarget.textContent = `Load Error: ${e}`
+    }
+  }
+
+  toggleTheme() {
+    this.theme = this.theme === "dark" ? "light" : "dark"
+    localStorage.setItem(KEY.theme, this.theme)
+    this.view.dispatch({
+      effects: this.themeCompartment.reconfigure(this.theme === "dark" ? oneDark : [])
+    })
+  }
+}

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -31,4 +31,3 @@ pin "@codemirror/legacy-modes/mode/ruby",
 pin "@codemirror/theme-one-dark", to: "https://esm.sh/@codemirror/theme-one-dark@6"
 # ハイライト（tags / HighlightStyle の提供元）
 pin "@lezer/highlight", to: "https://esm.sh/@lezer/highlight@1/es2022/highlight.mjs"
-pin "@hotwired/stimulus", to: "stimulus.min.js"

--- a/spec/services/judge0/client_spec.rb
+++ b/spec/services/judge0/client_spec.rb
@@ -1,9 +1,10 @@
 # spec/services/judge0/client_spec.rb
 require "rails_helper"
+require "base64"
 
 RSpec.describe Judge0::Client do
   describe "#run_ruby" do
-    it "submit→fetch を呼んで結果を返す (HTTParty をスタブ)" do
+    it "submit→fetch を呼び、Base64 フィールドを復号して結果を返す" do
       client = described_class.new
 
       submit_res = instance_double(
@@ -12,23 +13,27 @@ RSpec.describe Judge0::Client do
         parsed_response: { "token" => "tok" }
       )
 
+      # Judge0 からの fetch が Base64 で返ってくるケースを模擬
+      encoded_stdout = Base64.strict_encode64("OK\n")
       fetch_res = instance_double(
         HTTParty::Response,
         code: 200,
         parsed_response: {
-          "status" => { "id" => 3, "description" => "Accepted" },
-          "stdout" => "OK\n"
+          "status"  => { "id" => 3, "description" => "Accepted" },
+          "stdout"  => encoded_stdout,
+          "stderr"  => nil,
+          "message" => nil
         }
       )
 
       allow(described_class).to receive(:post).and_return(submit_res)
       allow(described_class).to receive(:get).and_return(fetch_res)
-      allow(client).to receive(:sleep)              # ループ高速化
+      allow(client).to receive(:sleep) # ループ高速化
 
       res = client.run_ruby("puts 'OK'")
 
       expect(res.dig("status", "description")).to eq("Accepted")
-      expect(res["stdout"]).to eq("OK\n")
+      expect(res["stdout"]).to eq("OK\n")  # ← 復号されていること
     end
   end
 end


### PR DESCRIPTION
### 概要
Stimulusコントローラで実行/初期データ読込/テーマ保存を実装を行なった。

**作業内容**

- Stimulusコントローラーの作成と編集
- CSRF トークンをapp/javascript/application.jsに設置
- 動作チェック（手動 / RSpec）