### PR TITLE
feat: 管理画面用BaseControllerを追加し、全/admin配下でadmin認可を共通化

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,13 @@
+# app/controllers/admin/base_controller.rb
+class Admin::BaseController < ApplicationController
+  before_action :require_admin!
+
+  private
+
+  def require_admin!
+    # ログインしていない or admin:false → 入口で閉め出す
+    unless current_user&.admin?
+      redirect_to root_path, alert: "管理者のみアクセス可能です"
+    end
+  end
+end

--- a/app/controllers/admin/book_sections_controller.rb
+++ b/app/controllers/admin/book_sections_controller.rb
@@ -1,4 +1,4 @@
-class Admin::BookSectionsController < ApplicationController
+class Admin::BookSectionsController < Admin::BaseController
   def index
     head :ok
   end

--- a/app/controllers/admin/books_controller.rb
+++ b/app/controllers/admin/books_controller.rb
@@ -1,4 +1,4 @@
-class Admin::BooksController < ApplicationController
+class Admin::BooksController < Admin::BaseController
   def index
     head :ok
   end

--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,4 +1,4 @@
-class Admin::DashboardsController < ApplicationController
+class Admin::DashboardsController < Admin::BaseController
   def index
     head :ok
   end

--- a/spec/requests/admin/authorization_smoke_spec.rb
+++ b/spec/requests/admin/authorization_smoke_spec.rb
@@ -1,0 +1,21 @@
+# spec/requests/admin/authorization_smoke_spec.rb
+require "rails_helper"
+
+RSpec.describe "Admin Authorization", type: :request do
+  let(:user)  { create(:user, admin: false) }
+  let(:admin) { create(:user, admin: true)  }
+
+  it "非adminは /admin に入れない" do
+    sign_in_as(user)
+    get admin_root_path
+    expect(response).to redirect_to(root_path)
+    follow_redirect!
+    expect(response.body).to include("管理者のみアクセス可能です")
+  end
+
+  it "adminは /admin に入れる" do
+    sign_in_as(admin)
+    get admin_root_path
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/admin/book_sections_spec.rb
+++ b/spec/requests/admin/book_sections_spec.rb
@@ -1,10 +1,12 @@
+# spec/requests/admin/book_sections_spec.rb
 require "rails_helper"
 
 RSpec.describe "Admin::BookSections", type: :request do
-  describe "GET /admin/book_sections" do
-    it "200 OK" do
-      get "/admin/book_sections"
-      expect(response).to have_http_status(:ok)
-    end
+  let(:admin) { create(:user, admin: true, password: "password") }
+
+  it "GET /admin/book_sections は 200" do
+    sign_in_as(admin)
+    get admin_book_sections_path
+    expect(response).to have_http_status(:ok)
   end
 end

--- a/spec/requests/admin/books_spec.rb
+++ b/spec/requests/admin/books_spec.rb
@@ -1,10 +1,12 @@
+# spec/requests/admin/books_spec.rb
 require "rails_helper"
 
 RSpec.describe "Admin::Books", type: :request do
-  describe "GET /admin/books" do
-    it "200 OK" do
-      get "/admin/books"
-      expect(response).to have_http_status(:ok)
-    end
+  let(:admin) { create(:user, admin: true, password: "password") }
+
+  it "GET /admin/books は 200" do
+    sign_in_as(admin)
+    get admin_books_path
+    expect(response).to have_http_status(:ok)
   end
 end

--- a/spec/requests/admin/dashboards_spec.rb
+++ b/spec/requests/admin/dashboards_spec.rb
@@ -1,11 +1,12 @@
+# spec/requests/admin/dashboards_spec.rb
 require "rails_helper"
 
 RSpec.describe "Admin::Dashboards", type: :request do
-  describe "GET /admin" do
-    it "200 OK" do
-      get "/admin"
-      # 仮実装なので 200 さえ返ればよい
-      expect(response).to have_http_status(:ok)
-    end
+  let(:admin) { create(:user, admin: true, password: "password") }
+
+  it "GET /admin は 200" do
+    sign_in_as(admin)
+    get admin_root_path
+    expect(response).to have_http_status(:ok)
   end
 end

--- a/spec/support/request_login_helper.rb
+++ b/spec/support/request_login_helper.rb
@@ -1,0 +1,13 @@
+# spec/support/request_login_helper.rb
+module RequestLoginHelper
+  # 通常ログイン（/session#create）を通す想定
+  def sign_in_as(user, password: "password")
+    post session_path, params: { email: user.email, password: password }
+    follow_redirect! if response.redirect?
+    user
+  end
+end
+
+RSpec.configure do |config|
+  config.include RequestLoginHelper, type: :request
+end


### PR DESCRIPTION
### 概要
管理画面用BaseControllerを追加し、全/admin配下でadmin認可の共通化を図った。

**作業内容**

- app/controllers/admin/base_controller.rbの作成と編集を行った
- app/controllers/admin/sessions_controller.rb を除く、すべてのadmin ディレクトリ配下のコントローラーファイルの継承先をadmin/base_controller.rbに変更
- RSpecによる検証