### PR TITLE
feat: 管理ログイン機能を実装（Admin::SessionsController, admin専用レイアウト, ログイン/ログアウト…

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,5 +1,23 @@
+# app/controllers/admin/sessions_controller.rb
 class Admin::SessionsController < ApplicationController
-  def new
-    head :ok
+  layout "admin"
+
+  def new; end
+
+  def create
+    user = User.find_by(email: params[:email])
+
+    if user&.admin? && user.authenticate(params[:password])
+      session[:user_id] = user.id
+      redirect_to admin_root_path, notice: "管理ログインしました"
+    else
+      flash.now[:alert] = "メールかパスワードが不正、または権限がありません"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    reset_session
+    redirect_to root_path, notice: "ログアウトしました"
   end
 end

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,4 +1,16 @@
-<div>
-  <h1 class="font-bold text-4xl">Admin::Sessions#new</h1>
-  <p>Find me in app/views/admin/sessions/new.html.erb</p>
-</div>
+<!-- app/views/admin/sessions/new.html.erb -->
+<h1 class="text-xl font-bold mb-4">Admin Login</h1>
+
+<%= form_with url: admin_session_path, method: :post, class: "space-y-4" do %>
+  <div>
+    <%= label_tag :email, "メールアドレス", class: "block text-sm mb-1" %>
+    <%= email_field_tag :email, params[:email], class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+  </div>
+
+  <div>
+    <%= label_tag :password, "パスワード", class: "block text-sm mb-1" %>
+    <%= password_field_tag :password, nil, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+  </div>
+
+  <%= submit_tag "ログイン", class: "px-4 py-2 rounded bg-slate-900 text-white" %>
+<% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,0 +1,59 @@
+<!-- app/views/layouts/admin.html.erb -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= content_for?(:title) ? yield(:title) : "Admin | Rails Learning Test" %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= yield :head %>
+
+    <!-- アイコン系 -->
+    <link rel="icon" href="/icon.png" type="image/png">
+    <link rel="icon" href="/icon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="/icon.png">
+
+    <!-- CSS / JS (Importmap) -->
+    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+
+    <!-- Quill CDN (管理画面でのみ読み込む) -->
+    <link href="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.snow.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.min.js"></script>
+  </head>
+
+  <body class="bg-slate-50 text-slate-800">
+    <!-- ヘッダー -->
+    <header class="border-b bg-white">
+      <div class="mx-auto max-w-5xl px-4 py-3 flex items-center justify-between">
+        <%= link_to "Admin", admin_root_path, class: "font-semibold" %>
+
+        <nav class="flex gap-3 text-sm">
+          <%= link_to "Dashboard", admin_root_path %>
+          <%= link_to "Books",     admin_books_path %>
+          <%= link_to "Sections",  admin_book_sections_path %>
+
+          <% if current_user&.admin? %>
+            <%= button_to "Logout",
+                          admin_session_path,
+                          method: :delete,
+                          class: "px-3 py-1 rounded bg-slate-900 text-white hover:bg-slate-800" %>
+          <% else %>
+            <%= link_to "Login",
+                        new_admin_session_path,
+                        class: "px-3 py-1 rounded ring-1 ring-slate-300 hover:bg-slate-50" %>
+          <% end %>
+        </nav>
+      </div>
+    </header>
+
+    <!-- メイン -->
+    <main class="mx-auto max-w-5xl px-4 py-6">
+      <%= render "shared/flash" %>
+      <%= yield %>
+    </main>
+  </body>
+</html>

--- a/spec/requests/admin/sessions_spec.rb
+++ b/spec/requests/admin/sessions_spec.rb
@@ -1,10 +1,23 @@
+# spec/requests/admin/sessions_spec.rb（ざっくりでOK）
 require "rails_helper"
 
 RSpec.describe "Admin::Sessions", type: :request do
-  describe "GET /admin/session/new" do
-    it "200 OK" do
-      get "/admin/session/new"
-      expect(response).to have_http_status(:ok)
-    end
+  let(:admin) { create(:user, admin: true, password: "secret", password_confirmation: "secret") }
+  let(:user)  { create(:user, admin: false, password: "secret", password_confirmation: "secret") }
+
+  it "admin はログインできる" do
+    post admin_session_path, params: { email: admin.email, password: "secret" }
+    expect(response).to redirect_to(admin_root_path)
+  end
+
+  it "非admin は拒否される" do
+    post admin_session_path, params: { email: user.email, password: "secret" }
+    expect(response).to have_http_status(:unprocessable_entity)
+  end
+
+  it "ログアウトできる" do
+    post admin_session_path, params: { email: admin.email, password: "secret" }
+    delete admin_session_path
+    expect(response).to redirect_to(root_path)
   end
 end


### PR DESCRIPTION
### 概要
管理ログイン機能を実装した。

**作業内容**

- セッション管理コントローラー（app/controllers/admin/sessions_controller.rb）の編集
- 管理画面ログインビュー（app/views/admin/sessions/new.html.erb）の編集
- 管理者画面用レイアウト（app/views/layouts/admin.html.erb）の作成と編集
- RSpecファイルの編集と実行