### PR TITLE
feat(admin): 管理画面ダッシュボードを実装

### DIFF
--- a/app/controllers/admin/books_controller.rb
+++ b/app/controllers/admin/books_controller.rb
@@ -1,13 +1,43 @@
 class Admin::BooksController < Admin::BaseController
+  layout "admin"
+
   def index
-    head :ok
+    @books = Book.order(updated_at: :desc).page(params[:page])
   end
 
   def new
-    head :ok
+    @book = Book.new
+  end
+
+  def create
+    @book = Book.new(book_params)
+    if @book.save
+      redirect_to admin_books_path, notice: "作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def edit
-    head :ok
+    @book = Book.find(params[:id])
+  end
+
+  def update
+    @book = Book.find(params[:id])
+    if @book.update(book_params)
+      redirect_to admin_books_path, notice: "更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    Book.find(params[:id]).destroy
+    redirect_to admin_books_path, notice: "削除しました"
+  end
+
+  private
+  def book_params
+    params.require(:book).permit(:title, :description)
   end
 end

--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,5 +1,9 @@
 class Admin::DashboardsController < Admin::BaseController
+  layout "admin"
+
   def index
-    head :ok
+    @books_count = Book.count
+    @sections_count = BookSection.count
+    # 余力があれば最近更新されたレコードなども追加できる
   end
 end

--- a/app/views/admin/books/_form.html.erb
+++ b/app/views/admin/books/_form.html.erb
@@ -1,0 +1,31 @@
+<%= form_with model: @book, url: (@book.new_record? ? admin_books_path : admin_book_path(@book)),
+              method: (@book.new_record? ? :post : :patch),
+              class: "space-y-4" do |f| %>
+
+  <% if @book.errors.any? %>
+    <div class="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">
+      <p><strong><%= @book.errors.count %></strong> 件のエラーがあります：</p>
+      <ul class="list-disc pl-5 mt-1">
+        <% @book.errors.full_messages.each do |m| %>
+          <li><%= m %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :title, class: "block text-sm text-slate-600" %>
+    <%= f.text_field :title, class: "w-full rounded border px-3 py-2" %>
+  </div>
+
+  <div>
+    <%= f.label :description, class: "block text-sm text-slate-600" %>
+    <%= f.text_area :description, rows: 5, class: "w-full rounded border px-3 py-2" %>
+  </div>
+
+  <div class="flex gap-2">
+    <%= f.submit (@book.new_record? ? "作成する" : "更新する"),
+        class: "px-4 py-2 rounded bg-slate-900 text-white" %>
+    <%= link_to "一覧に戻る", admin_books_path, class: "px-4 py-2 rounded ring-1 ring-slate-300" %>
+  </div>
+<% end %>

--- a/app/views/admin/books/edit.html.erb
+++ b/app/views/admin/books/edit.html.erb
@@ -1,4 +1,3 @@
-<div>
-  <h1 class="font-bold text-4xl">Admin::Books#edit</h1>
-  <p>Find me in app/views/admin/books/edit.html.erb</p>
-</div>
+<% content_for :title, "Books / 編集" %>
+<h1 class="text-xl font-semibold mb-4">Book を編集</h1>
+<%= render "form", book: @book %>

--- a/app/views/admin/books/index.html.erb
+++ b/app/views/admin/books/index.html.erb
@@ -1,4 +1,35 @@
-<div>
-  <h1 class="font-bold text-4xl">Admin::Books#index</h1>
-  <p>Find me in app/views/admin/books/index.html.erb</p>
+<% content_for :title, "Books" %>
+<div class="flex items-center justify-between mb-4">
+  <h1 class="text-2xl font-semibold">Books</h1>
+  <%= link_to "＋ 新規作成", new_admin_book_path, class: "px-3 py-2 rounded bg-slate-900 text-white" %>
+</div>
+
+<table class="w-full text-left border rounded bg-white">
+  <thead>
+    <tr class="border-b bg-slate-50">
+      <th class="px-3 py-2">ID</th>
+      <th class="px-3 py-2">タイトル</th>
+      <th class="px-3 py-2">説明</th>
+      <th class="px-3 py-2">更新日</th>
+      <th class="px-3 py-2"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @books.each do |b| %>
+      <tr class="border-b">
+        <td class="px-3 py-2"><%= b.id %></td>
+        <td class="px-3 py-2"><%= b.title %></td>
+        <td class="px-3 py-2 text-slate-600"><%= truncate(b.description, length: 80) %></td>
+        <td class="px-3 py-2 text-slate-500"><%= l b.updated_at, format: :short %></td>
+        <td class="px-3 py-2 text-right">
+          <%= link_to "編集", edit_admin_book_path(b), class: "mr-2 text-sky-700 hover:underline" %>
+          <%= link_to "削除", admin_book_path(b), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" }, class: "text-red-700 hover:underline" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<div class="mt-4">
+  <%= paginate @books if defined?(paginate) %>
 </div>

--- a/app/views/admin/books/new.html.erb
+++ b/app/views/admin/books/new.html.erb
@@ -1,4 +1,3 @@
-<div>
-  <h1 class="font-bold text-4xl">Admin::Books#new</h1>
-  <p>Find me in app/views/admin/books/new.html.erb</p>
-</div>
+<% content_for :title, "Books / 新規作成" %>
+<h1 class="text-xl font-semibold mb-4">Book を新規作成</h1>
+<%= render "form", book: @book %>

--- a/app/views/admin/dashboards/index.html.erb
+++ b/app/views/admin/dashboards/index.html.erb
@@ -1,4 +1,13 @@
-<div>
-  <h1 class="font-bold text-4xl">Admin::Dashboards#index</h1>
-  <p>Find me in app/views/admin/dashboards/index.html.erb</p>
+<% content_for :title, "Dashboard" %>
+<h1 class="text-2xl font-semibold mb-4">Dashboard</h1>
+
+<div class="grid sm:grid-cols-2 gap-4">
+  <div class="rounded-xl ring-1 ring-slate-200 p-4 bg-white">
+    <div class="text-slate-500 text-sm">Books</div>
+    <div class="text-3xl font-bold"><%= number_with_delimiter(@books_count) %></div>
+  </div>
+  <div class="rounded-xl ring-1 ring-slate-200 p-4 bg-white">
+    <div class="text-slate-500 text-sm">Sections</div>
+    <div class="text-3xl font-bold"><%= number_with_delimiter(@sections_count) %></div>
+  </div>
 </div>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -7,20 +7,20 @@
       <!-- だれでも表示 -->
       <%= link_to "Code Editor", editor_path,
           class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-
-      <!-- だれでも表示：Rails Books -->
       <%= link_to "Rails Books", books_path,
           class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
 
       <% if logged_in? %>
         <%= link_to "PreCode", pre_codes_path,
             class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-
         <%= link_to "Code Library", code_libraries_path,
             class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
 
-        <%= link_to "新規作成", new_pre_code_path,
-            class: "px-3 py-1 rounded-lg bg-slate-900 text-white hover:bg-slate-800" %>
+        <!-- ★ 管理者だけに表示 -->
+        <% if current_user&.admin? %>
+          <%= link_to "管理画面", admin_root_path,
+              class: "px-3 py-1 rounded-lg bg-slate-900 text-white hover:bg-slate-800" %>
+        <% end %>
 
         <%= link_to "ログアウト", session_path,
             data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" },
@@ -28,10 +28,8 @@
       <% else %>
         <%= link_to "Code Library", code_libraries_path,
             class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-
         <%= link_to "ログイン", new_session_path,
             class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-
         <%= link_to "新規登録", new_user_path,
             class: "px-3 py-1 rounded-lg bg-slate-900 text-white hover:bg-slate-800" %>
       <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,12 @@
+# config/locales/ja.yml
+ja:
+  date:
+    formats:
+      default: "%Y/%m/%d"
+      short:   "%m/%d"
+      long:    "%Y年%-m月%-d日(%a)"
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M"
+      short:   "%m/%d %H:%M"
+      long:    "%Y年%-m月%-d日 %H:%M"

--- a/spec/requests/admin/books_spec.rb
+++ b/spec/requests/admin/books_spec.rb
@@ -2,11 +2,36 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Books", type: :request do
-  let(:admin) { create(:user, admin: true, password: "password") }
+  let(:admin) { create(:user, admin: true) }
 
-  it "GET /admin/books は 200" do
-    sign_in_as(admin)
+  before { sign_in_as(admin) }
+
+  it "GET /admin/books works" do
     get admin_books_path
     expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Books")
+  end
+
+  it "POST /admin/books creates a book" do
+    post admin_books_path, params: { book: { title: "T", description: "D" } }
+    expect(response).to redirect_to(admin_books_path)
+    follow_redirect!
+    expect(response.body).to include("作成しました")
+  end
+
+  it "PATCH /admin/books/:id updates a book" do
+    book = create(:book, title: "Old", description: "Desc")
+    patch admin_book_path(book), params: { book: { title: "New" } }
+    expect(response).to redirect_to(admin_books_path)
+    follow_redirect!
+    expect(response.body).to include("更新しました")
+  end
+
+  it "DELETE /admin/books/:id removes a book" do
+    book = create(:book)
+    delete admin_book_path(book)
+    expect(response).to redirect_to(admin_books_path)
+    follow_redirect!
+    expect(response.body).to include("削除しました")
   end
 end

--- a/spec/requests/admin/dashboards_spec.rb
+++ b/spec/requests/admin/dashboards_spec.rb
@@ -1,12 +1,12 @@
-# spec/requests/admin/dashboards_spec.rb
 require "rails_helper"
 
 RSpec.describe "Admin::Dashboards", type: :request do
-  let(:admin) { create(:user, admin: true, password: "password") }
+  let(:admin) { create(:user, admin: true) }
 
-  it "GET /admin は 200" do
+  it "GET /admin returns 200 for admin" do
     sign_in_as(admin)
     get admin_root_path
     expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Dashboard")
   end
 end


### PR DESCRIPTION
### 概要
管理画面ダッシュボードを実装

**作業内容**

- 管理画面ダッシュボード用のコントローラー（app/controllers/admin/dashboards_controller.rb）の編集を行った
- 管理画面ダッシュボード用のビュー（app/views/admin/dashboards/index.html.erb）の編集を行った
- ヘッダー（app/views/shared/_nav.html.erb）を修正：条件分岐で管理者画面へ行けるように設定した
- 動作確認（手動 / RSpec）を行った


### 概要
BooksのCRUDを実装した

**作業内容**

- Books目次のコントローラー（app/controllers/admin/books_controller.rb）を編集した
- app/views/admin/books/_form.html.erbを作成した
- Books目次のビューファイル（index, new, edit, _form）を編集した
- app/views/layouts/admin.html.erb のヘッダーにBooksへのリンクを加えた
-  i18n で時刻に関する日本語フォーマットを作成した
- 動作チェック（手動 / RSpec）を行った