### PR TITLE
デプロイエラーの修正：cacheのロード

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,4 +3,5 @@ set -o errexit
 bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
+bundle exec rails db:schema:load:cache
 bundle exec rails db:migrate


### PR DESCRIPTION
### 概要
デプロイエラーの修正を行った。

**作業内容**

relation "solid_cache_entries" does not existというエラーが出ていたので、
cacheを読み込む設定を行った。