### PR TITLE
Create solid_cache_entries table via migration

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,5 +3,4 @@ set -o errexit
 bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
-bundle exec rails db:schema:load:cache
 bundle exec rails db:migrate

--- a/db/migrate/20250825031316_create_solid_cache_entries.rb
+++ b/db/migrate/20250825031316_create_solid_cache_entries.rb
@@ -10,7 +10,7 @@ class CreateSolidCacheEntries < ActiveRecord::Migration[8.0]
     end
 
     add_index :solid_cache_entries, :byte_size
-    add_index :solid_cache_entries, [:key_hash, :byte_size],
+    add_index :solid_cache_entries, [ :key_hash, :byte_size ],
               name: "index_solid_cache_entries_on_key_hash_and_byte_size"
     add_index :solid_cache_entries, :key_hash, unique: true
   end

--- a/db/migrate/20250825031316_create_solid_cache_entries.rb
+++ b/db/migrate/20250825031316_create_solid_cache_entries.rb
@@ -1,0 +1,17 @@
+class CreateSolidCacheEntries < ActiveRecord::Migration[8.0]
+  def change
+    # Solid Cache は主キーを持たないので id: false
+    create_table :solid_cache_entries, id: false do |t|
+      t.binary   :key,       null: false, limit: 1024
+      t.binary   :value,     null: false, limit: 536_870_912
+      t.datetime :created_at,            null: false
+      t.integer  :key_hash,  null: false, limit: 8
+      t.integer  :byte_size, null: false, limit: 4
+    end
+
+    add_index :solid_cache_entries, :byte_size
+    add_index :solid_cache_entries, [:key_hash, :byte_size],
+              name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    add_index :solid_cache_entries, :key_hash, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_23_133942) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_25_031316) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -84,6 +84,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_23_133942) do
     t.index ["title"], name: "index_pre_codes_on_title"
     t.index ["user_id", "created_at"], name: "index_pre_codes_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_pre_codes_on_user_id"
+  end
+
+  create_table "solid_cache_entries", id: false, force: :cascade do |t|
+    t.binary "key", null: false
+    t.binary "value", null: false
+    t.datetime "created_at", null: false
+    t.bigint "key_hash", null: false
+    t.integer "byte_size", null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 
   create_table "used_codes", force: :cascade do |t|


### PR DESCRIPTION
### 概要
スキーマ読み込みタスクを使わずに、通常のマイグレーションで solid_cache_entries テーブルを作成

**背景**

db:schema:load:cacheは破壊的コマンドということでビルド失敗になってしまった。
なので、db:schema:load:cacheコマンドを使わずに、通常のマイグレーションでsolid_cache_entries テーブルを作成した