### PR TITLE
静的ページ(help/terms/privacy)とお問い合わせ(contact)を追加し、パンくず・ナビ導線を整備（Googleフォーム…

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,7 @@
+# app/controllers/static_pages_controller.rb
+class StaticPagesController < ApplicationController
+  def help;    end
+  def terms;   end
+  def privacy; end
+  def contact; end
+end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,0 +1,2 @@
+module StaticPagesHelper
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,4 +30,13 @@
       <%= yield %>
     </main>
   </body>
+
+  <footer class="mt-12 py-8 text-sm text-slate-500">
+    <div class="mx-auto max-w-md px-4 flex flex-wrap gap-4">
+      <%= link_to "利用規約", terms_path, class: "hover:underline" %>
+      <%= link_to "プライバシー", privacy_path, class: "hover:underline" %>
+      <%= link_to "ヘルプ", help_path, class: "hover:underline" %>
+      <%= link_to "お問い合わせ", contact_path, class: "hover:underline" %>
+    </div>
+  </footer>
 </html>

--- a/app/views/static_pages/contact.html.erb
+++ b/app/views/static_pages/contact.html.erb
@@ -1,0 +1,19 @@
+<!-- app/views/static_pages/contact.html.erb -->
+<%# パンくず %>
+<% breadcrumb :root %>
+<% breadcrumb :contact %>
+<%= render "shared/breadcrumbs" %>
+
+<% content_for :title, "お問い合わせ" %>
+<h1 class="text-2xl font-bold mb-4">お問い合わせ</h1>
+
+<div class="bg-white rounded-xl shadow p-4 overflow-hidden">
+  <iframe
+    src="<%= ENV.fetch('GOOGLE_FORM_URL', 'https://example.com/dummy-form') %>"
+    class="w-full border-0"
+    style="min-height: 1750px; height: 95vh;"
+    loading="lazy"
+    referrerpolicy="no-referrer-when-downgrade"
+    allowfullscreen>
+  </iframe>
+</div>

--- a/app/views/static_pages/help.html.erb
+++ b/app/views/static_pages/help.html.erb
@@ -1,0 +1,19 @@
+<!-- app/views/static_pages/help.html.erb -->
+<% breadcrumb :root %>
+<% breadcrumb :help %>
+<%= render "shared/breadcrumbs" %>
+
+<% content_for :title, "ヘルプ" %>
+<h1 class="text-2xl font-bold mb-4">ヘルプ</h1>
+<section class="prose max-w-none">
+  <h2>使い方</h2>
+  <p>このサービスの基本操作や各機能の説明をまとめます。</p>
+
+  <h3>主な機能</h3>
+  <ul>
+    <li>Code Editor（実行・テーマ切替・初期データ）</li>
+    <li>Rails Books（目次・前後ページ）</li>
+    <li>PreCode / CodeLibrary（ランキング・いいね）</li>
+    <li>…など</li>
+  </ul>
+</section>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,13 @@
+<!-- app/views/static_pages/privacy.html.erb -->
+<% breadcrumb :root %>
+<% breadcrumb :privacy %>
+<%= render "shared/breadcrumbs" %>
+
+<% content_for :title, "プライバシーポリシー" %>
+<h1 class="text-2xl font-bold mb-4">プライバシーポリシー</h1>
+<section class="prose max-w-none">
+  <h2>個人情報の利用目的</h2>
+  <p>…</p>
+  <h2>アクセス解析・Cookie</h2>
+  <p>…</p>
+</section>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,13 @@
+<!-- app/views/static_pages/terms.html.erb -->
+<% breadcrumb :root %>
+<% breadcrumb :terms %>
+<%= render "shared/breadcrumbs" %>
+
+<% content_for :title, "利用規約" %>
+<h1 class="text-2xl font-bold mb-4">利用規約</h1>
+<section class="prose max-w-none">
+  <h2>第1条 適用</h2>
+  <p>…（後で本番文面に差し替え）</p>
+  <h2>第2条 禁止事項</h2>
+  <ul><li>…</li></ul>
+</section>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -68,6 +68,27 @@ crumb :code_library do |lib|
   link lib.title, code_library_path(lib)
 end
 
+# --- Static pages ---
+crumb :help do
+  parent :root
+  link "ヘルプ", help_path
+end
+
+crumb :terms do
+  parent :root
+  link "利用規約", terms_path
+end
+
+crumb :privacy do
+  parent :root
+  link "プライバシーポリシー", privacy_path
+end
+
+crumb :contact do
+  parent :root
+  link "お問い合わせ", contact_path
+end
+
 
 # ============================================================
 # 管理（Admin）エリア

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
+  # 静的ページ
+  get "help",    to: "static_pages#help"
+  get "terms",   to: "static_pages#terms"
+  get "privacy", to: "static_pages#privacy"
+  get "contact", to: "static_pages#contact"
   get "tests/index"
 
   # Render のヘルスチェック用

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,0 +1,9 @@
+# spec/requests/static_pages_spec.rb
+require "rails_helper"
+
+RSpec.describe "StaticPages", type: :request do
+  it { get help_path;    expect(response).to have_http_status(:ok) }
+  it { get terms_path;   expect(response).to have_http_status(:ok) }
+  it { get privacy_path; expect(response).to have_http_status(:ok) }
+  it { get contact_path; expect(response).to have_http_status(:ok) }
+end


### PR DESCRIPTION
### 概要
静的ページ（help/terms/privacy）とお問い合わせ（Googleフォーム埋め込み）を追加し、パンくず＆ナビ導線を整備。

**作業内容**

- ルーティングと StaticPagesController を追加（help/terms/privacy/contact）
- 4ページのビューを作成（パンくず設置）
- Gretelに :help/:terms/:privacy/:contact を追加
- ヘッダー/フッターにリンクを配置、フォームURLは GOOGLE_FORM_URL で外部化
- 静的ページの簡易リクエストSpecを追加