### PR TITLE
レスポンシブ基盤整備：レイアウト幅統一・スマホはバーガーモーダル集約・Heroicons導入と主要画面のアイコン適用（いいね/使った/書類…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,9 @@ gem "httparty"
 # パンくず機能
 gem "gretel"
 
+# アイコン
+gem "heroicon-rails"
+
 gem "image_processing", "~> 1.12"  # ActiveStorageで画像のリサイズやサムネイル生成を行うGem
 gem "mini_magick"                  # 画像処理ライブラリImageMagickのRubyラッパー
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,9 @@ GEM
       actionview (>= 6.1)
       railties (>= 6.1)
     hashie (5.0.0)
+    heroicon-rails (0.2.9)
+      activesupport (>= 7.0.8)
+      nokogiri (>= 1.14.3)
     httparty (0.23.1)
       csv
       mini_mime (>= 1.0.0)
@@ -500,6 +503,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   gretel
+  heroicon-rails
   httparty
   image_processing (~> 1.12)
   importmap-rails

--- a/app/views/books/_book.html.erb
+++ b/app/views/books/_book.html.erb
@@ -9,7 +9,8 @@
 
     <div class="text-xs text-slate-500">
       <span class="inline-flex items-center gap-1">
-        📄 <%= number_with_delimiter(book.book_sections_count || 0) %>
+        <%= heroicon "document-text", variant: :outline, options: { class: "w-4 h-4" } %>
+        <%= number_with_delimiter(book.book_sections_count || 0) %>
       </span>
     </div>
   </li>

--- a/app/views/code_libraries/_actions.html.erb
+++ b/app/views/code_libraries/_actions.html.erb
@@ -3,23 +3,29 @@
 <div id="<%= dom_id(pre_code, :actions) %>" class="flex gap-2">
   <% if logged_in? %>
     <% if current_like %>
-      <%= button_to "♥ #{pre_code.like_count}",
-            like_path(current_like),
+      <%= button_to like_path(current_like),
             method: :delete,
-            form: { data: { turbo_stream: true } },
-            class: "px-3 py-1 rounded bg-rose-600 text-white" %>
+            form:   { data: { turbo_stream: true } },
+            class:  "px-3 py-1 rounded bg-rose-600 text-white inline-flex items-center gap-1" do %>
+        <%= heroicon "heart", variant: :solid,  options: { class: "w-4 h-4" } %>
+        <%= pre_code.like_count %>
+      <% end %>
     <% else %>
-      <%= button_to "♡ #{pre_code.like_count}",
-            likes_path(pre_code_id: pre_code.id),
+      <%= button_to likes_path(pre_code_id: pre_code.id),
             method: :post,
-            form: { data: { turbo_stream: true } },
-            class: "px-3 py-1 rounded ring-1 ring-slate-300" %>
+            form:   { data: { turbo_stream: true } },
+            class:  "px-3 py-1 rounded ring-1 ring-slate-300 inline-flex items-center gap-1" do %>
+        <%= heroicon "heart", variant: :outline, options: { class: "w-4 h-4" } %>
+        <%= pre_code.like_count %>
+      <% end %>
     <% end %>
+  <% end %>
 
-    <%= button_to "使った(#{pre_code.use_count})",
-          used_codes_path(pre_code_id: pre_code.id),
-          method: :post,
-          form: { data: { turbo_stream: true } },
-          class: "px-3 py-1 rounded bg-slate-900 text-white" %>
+  <%= button_to used_codes_path(pre_code_id: pre_code.id),
+        method: :post,
+        form:   { data: { turbo_stream: true } },
+        class:  "px-3 py-1 rounded bg-slate-900 text-white inline-flex items-center gap-1" do %>
+    <%= heroicon "briefcase", variant: :solid, options: { class: "w-4 h-4" } %>
+    <%= pre_code.use_count %>
   <% end %>
 </div>

--- a/app/views/code_libraries/index.html.erb
+++ b/app/views/code_libraries/index.html.erb
@@ -43,7 +43,14 @@
             <p class="text-sm text-slate-500 mt-1"><%= truncate(pc.description, length: 100) %></p>
           </div>
           <div class="text-sm text-slate-500">
-            👍 <%= pc.like_count %> ・ 🧰 <%= pc.use_count %>
+            <span class="inline-flex items-center gap-1 mr-4 align-middle">
+              <%= heroicon "heart", variant: :solid, options: { class: "w-4 h-4" } %>
+              <%= pc.like_count %>
+            </span>
+            <span class="inline-flex items-center gap-1 align-middle">
+              <%= heroicon "briefcase", variant: :outline, options: { class: "w-4 h-4" } %>
+              <%= pc.use_count %>
+            </span>
           </div>
         </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
     <%= render "shared/nav" %>
 
     <!-- メイン -->
-    <main class="mx-auto max-w-md px-4 py-8">
+    <main class="mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-6">
       <%= render "shared/flash" %>
       <%= yield %>
     </main>

--- a/app/views/shared/_modal_panel.html.erb
+++ b/app/views/shared/_modal_panel.html.erb
@@ -1,66 +1,105 @@
 <!-- app/views/shared/_modal_panel.html.erb -->
-<div
-  data-modal-target="container"
-  class="hidden fixed inset-0 z-50 grid place-items-start md:place-items-center pt-24 md:pt-0"
-  role="dialog" aria-modal="true" aria-labelledby="user-menu-title">
+<div data-modal-target="container"
+     class="hidden fixed inset-0 z-50 grid place-items-start md:place-items-center pt-24 md:pt-0"
+     role="dialog" aria-modal="true" aria-labelledby="user-menu-title">
 
   <!-- 背景 -->
-  <div
-    data-modal-target="backdrop"
-    class="absolute inset-0 bg-black/40"
-    data-action="click->modal#backdrop"></div>
+  <div data-modal-target="backdrop"
+       class="absolute inset-0 bg-black/40"
+       data-action="click->modal#backdrop"></div>
 
   <!-- パネル -->
-  <div
-    data-modal-target="panel"
-    class="relative mx-auto w-11/12 max-w-lg rounded-2xl bg-white p-8 shadow-lg text-center">
+  <div data-modal-target="panel"
+       class="relative mx-auto w-11/12 max-w-lg rounded-2xl bg-white p-8 shadow-lg text-center">
 
     <div class="mb-4 flex items-center justify-center">
       <h2 id="user-menu-title" class="text-xl font-semibold">メニュー</h2>
-      <button
-        class="absolute right-4 top-4 text-slate-500 hover:text-slate-700"
-        data-action="click->modal#close"
-        aria-label="閉じる">×</button>
+      <button class="absolute right-4 top-4 text-slate-500 hover:text-slate-700"
+              data-action="click->modal#close" aria-label="閉じる">
+        <%= heroicon "x-mark", variant: :solid, options: { class: "w-6 h-6" } %>
+      </button>
     </div>
 
-    <% if logged_in? %>
-      <ul class="space-y-3">
-        <li><%= link_to "アプリの使い方", help_path,         class: "block hover:underline text-center" %></li>
-        <li><%= link_to "お問い合わせ",   contact_path,      class: "block hover:underline text-center" %></li>
-        <li><%= link_to "利用規約",       terms_path,        class: "block hover:underline text-center" %></li>
-        <li><%= link_to "プライバシーポリシー", privacy_path, class: "block hover:underline text-center" %></li>
+    <%# ===================== PC 用（lg以上だけ表示） ===================== %>
+    <div class="hidden lg:block">
+      <% if logged_in? %>
+        <ul class="space-y-3">
+          <li><%= link_to "アプリの使い方",       help_path,    class: "block hover:underline text-center" %></li>
+          <li><%= link_to "お問い合わせ",         contact_path, class: "block hover:underline text-center" %></li>
+          <li><%= link_to "利用規約",             terms_path,   class: "block hover:underline text-center" %></li>
+          <li><%= link_to "プライバシーポリシー", privacy_path, class: "block hover:underline text-center" %></li>
 
-        <% if current_user&.admin? %>
+          <%# ※PC のみ管理者リンクを出す %>
+          <% if current_user&.admin? %>
+            <li class="pt-2 border-t">
+              <%= link_to "管理画面", admin_root_path, class: "block hover:underline text-center" %>
+            </li>
+          <% end %>
+
           <li class="pt-2 border-t">
-            <%= link_to "管理画面へログイン", admin_root_path, class: "block hover:underline text-center" %>
+            <%= link_to "ログアウト", session_path,
+                  data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" },
+                  class: "block hover:underline text-center" %>
           </li>
-        <% end %>
+        </ul>
+      <% else %>
+        <ul class="space-y-3">
+          <li><%= link_to "アプリの使い方",       help_path,    class: "block hover:underline text-center" %></li>
+          <li><%= link_to "お問い合わせ",         contact_path, class: "block hover:underline text-center" %></li>
+          <li><%= link_to "利用規約",             terms_path,   class: "block hover:underline text-center" %></li>
+          <li><%= link_to "プライバシーポリシー", privacy_path, class: "block hover:underline text-center" %></li>
+          <li class="pt-2 border-t"><%= link_to "ログイン", new_session_path, class: "block hover:underline text-center" %></li>
+          <li><%= link_to "新規登録", new_user_path, class: "block hover:underline text-center" %></li>
+        </ul>
+      <% end %>
+    </div>
 
-        <li class="pt-2 border-t">
-          <%= link_to "ログアウト", session_path,
-                      data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" },
-                      class: "block hover:underline text-center" %>
-        </li>
-      </ul>
-    <% else %>
-      <ul class="space-y-3">
-        <li><%= link_to "アプリの使い方",   help_path,        class: "block hover:underline text-center" %></li>
-        <li><%= link_to "お問い合わせ",     contact_path,     class: "block hover:underline text-center" %></li>
-        <li><%= link_to "利用規約",         terms_path,       class: "block hover:underline text-center" %></li>
-        <li><%= link_to "プライバシーポリシー", privacy_path, class: "block hover:underline text-center" %></li>
-        <li class="pt-2 border-t">
-          <%= link_to "ログイン",     new_session_path, class: "block hover:underline text-center" %>
-        </li>
-        <li>
-          <%= link_to "新規登録",     new_user_path,    class: "block hover:underline text-center" %>
-        </li>
-      </ul>
-    <% end %>
+    <%# ============== スマホ/タブレット用（lg未満のみ表示） ============== %>
+    <div class="lg:hidden">
+      <% if logged_in? %>
+        <ul class="space-y-3">
+          <%# まずアプリ内主要リンク %>
+          <li><%= link_to "Code Editor",  editor_path,      class: "block hover:underline text-center" %></li>
+          <li><%= link_to "Rails Books",  books_path,       class: "block hover:underline text-center" %></li>
+          <li><%= link_to "PreCode",      pre_codes_path,   class: "block hover:underline text-center" %></li>
+          <li><%= link_to "Code Library", code_libraries_path, class: "block hover:underline text-center" %></li>
+
+          <%# つづいて静的ページ %>
+          <li class="pt-2 border-t"><%= link_to "アプリの使い方",       help_path,    class: "block hover:underline text-center" %></li>
+          <li><%= link_to "お問い合わせ",         contact_path, class: "block hover:underline text-center" %></li>
+          <li><%= link_to "利用規約",             terms_path,   class: "block hover:underline text-center" %></li>
+          <li><%= link_to "プライバシーポリシー", privacy_path, class: "block hover:underline text-center" %></li>
+
+          <%# ※スマホ/タブレットでは管理画面リンクは出さない %>
+
+          <li class="pt-2 border-t">
+            <%= link_to "ログアウト", session_path,
+                  data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" },
+                  class: "block hover:underline text-center" %>
+          </li>
+        </ul>
+      <% else %>
+        <ul class="space-y-3">
+          <%# 未ログイン時：ログイン導線 + 主要リンク %>
+          <li><%= link_to "ログイン", new_session_path, class: "block hover:underline text-center" %></li>
+          <li><%= link_to "新規登録", new_user_path,    class: "block hover:underline text-center" %></li>
+
+          <li class="pt-2 border-t"><%= link_to "Code Editor",  editor_path,      class: "block hover:underline text-center" %></li>
+          <li><%= link_to "Rails Books",  books_path,       class: "block hover:underline text-center" %></li>
+          <li><%= link_to "PreCode",      pre_codes_path,   class: "block hover:underline text-center" %></li>
+          <li><%= link_to "Code Library", code_libraries_path, class: "block hover:underline text-center" %></li>
+
+          <li class="pt-2 border-t"><%= link_to "アプリの使い方",       help_path,    class: "block hover:underline text-center" %></li>
+          <li><%= link_to "お問い合わせ",         contact_path, class: "block hover:underline text-center" %></li>
+          <li><%= link_to "利用規約",             terms_path,   class: "block hover:underline text-center" %></li>
+          <li><%= link_to "プライバシーポリシー", privacy_path, class: "block hover:underline text-center" %></li>
+        </ul>
+      <% end %>
+    </div>
 
     <div class="mt-6 flex justify-center">
-      <button
-        class="inline-flex items-center rounded-lg bg-rose-600 px-5 py-2 text-white hover:bg-rose-700"
-        data-action="click->modal#close">閉じる</button>
+      <button class="inline-flex items-center rounded-lg bg-rose-600 px-5 py-2 text-white hover:bg-rose-700"
+              data-action="click->modal#close">閉じる</button>
     </div>
   </div>
 </div>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,41 +1,40 @@
 <!-- app/views/shared/_nav.html.erb -->
 <header class="border-b bg-white">
-  <!-- ここをコントローラの“親”にする（トリガーとモーダルを同じスコープに） -->
-  <div class="mx-auto max-w-3xl px-4 py-3 flex items-center justify-between"
+  <!-- モーダルの controller スコープ（トリガーとモーダルを同じ親に） -->
+  <div class="mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-3 flex items-center justify-between"
        data-controller="modal">
 
-    <%= link_to "RailsLearning", root_path, class: "font-semibold" %>
+    <!-- タイトル（常時表示） -->
+    <%= link_to root_path, class: "font-semibold text-center md:text-left flex items-center gap-2" do %>
+      <%= heroicon "rocket-launch", variant: :outline, options: { class: "w-6 h-6" } %>
+      <span>RailsLearning</span>
+    <% end %>
 
-    <!-- この位置でモーダルを描画（同じ controller スコープ内） -->
-    <%= render "shared/modal_panel" %>
-
-    <!-- グローバルナビ（従来のリンク） -->
-    <nav class="flex items-center gap-3 text-sm px-4 py-2">
-      <%# だれでも表示 %>
-      <%= link_to "Code Editor", editor_path,
-          class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-      <%= link_to "Rails Books", books_path,
-          class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-      <%= link_to "PreCode", pre_codes_path,
-          class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-      <%= link_to "Code Library", code_libraries_path,
-          class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
-
-      <%# ログイン時は 追加アクション無し（ログアウト/管理はモーダルへ集約） %>
-      <% if logged_in? %>
-      <% else %>
-        <%# 未ログイン時は ヘッダでは「ログイン」のみ表示（新規登録はモーダルへ） %>
-        <%= link_to "ログイン", new_session_path,
+    <!-- グローバルナビ：PCのみ表示（lg以上） -->
+    <nav class="hidden lg:flex items-center gap-3 text-sm">
+      <%= link_to "Code Editor",  editor_path,
             class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
+      <%= link_to "Rails Books",  books_path,
+            class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
+      <%= link_to "PreCode",      pre_codes_path,
+            class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
+      <%= link_to "Code Library", code_libraries_path,
+            class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
+
+      <% unless logged_in? %>
+        <%= link_to "ログイン", new_session_path,
+              class: "px-3 py-1 rounded-lg ring-1 ring-slate-300 hover:bg-slate-50" %>
       <% end %>
     </nav>
 
-    <!-- ハンバーガーボタン -->
-    <button
-      class="p-2 rounded-lg hover:bg-slate-100"
-      data-action="click->modal#open"
-      aria-label="メニューを開く">
-      ≡
+    <!-- ハンバーガー（常時表示） -->
+    <button class="p-2 rounded-lg hover:bg-slate-100 md:hidden lg:block"
+            data-action="click->modal#open"
+            aria-label="メニューを開く">
+      <%= heroicon "bars-3", options: { class: "w-6 h-6 text-slate-500" } %>
     </button>
+
+    <!-- モーダル（同一スコープ内で描画） -->
+    <%= render "shared/modal_panel" %>
   </div>
 </header>


### PR DESCRIPTION
### 概要
主要レイアウトを整理し、スマホはヘッダーをバーガーモーダルに集約、Heroicons を導入してUIを統一した。

**作業内容**

- application.html.erb の main を標準化（max-w-6xl px-4 md:px-6 lg:px-8 py-6）し、狭すぎる幅指定を整理
- ヘッダー：PCは従来ナビ、スマホ/タブレットはバーガーモーダルへ集約（Stimulus モーダル活用）
- Heroicons を導入し、各所に適用（バーガー、モーダル×、CodeLibraryの❤️/🧰、Rails Booksの📄、ヘッダータイトル横）
- CodeLibrary の「いいね」周りを整備し、削除時のパスを like_path(current_like) に修正（トグル可）