### PR TITLE
静的ページ（ヘルプ/利用規約/プライバシー）を追加整備し、レイアウトを見直してフッターのsticky化と表示崩れを解消

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,25 +20,39 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="bg-slate-50 text-slate-800">
+  <body class="min-h-screen flex flex-col bg-slate-50 text-slate-800">
     <!-- ヘッダー -->
     <%= render "shared/nav" %>
 
-    <!-- メイン -->
-    <main class="<%= content_for?(:page_container_class) \
+    <!-- メイン（高さだけ担当） -->
+    <main class="flex-1">
+      <!-- 幅・左右余白はここで集中管理 -->
+      <div class="<%= content_for?(:page_container_class) \
                     ? yield(:page_container_class) \
                     : 'mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-6' %>">
-      <%= render "shared/flash" %>
-      <%= yield %>
+        <%= render "shared/flash" %>
+        <%= yield %>
+      </div>
     </main>
-  </body>
 
-  <footer class="mt-12 py-8 text-sm text-slate-500">
-    <div class="mx-auto max-w-md px-4 flex flex-wrap gap-4">
-      <%= link_to "利用規約", terms_path, class: "hover:underline" %>
-      <%= link_to "プライバシー", privacy_path, class: "hover:underline" %>
-      <%= link_to "ヘルプ", help_path, class: "hover:underline" %>
-      <%= link_to "お問い合わせ", contact_path, class: "hover:underline" %>
-    </div>
-  </footer>
+    <!-- フッター -->
+    <footer class="mt-12 border-t bg-white/50">
+      <div class="mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-6">
+        <div class="grid grid-cols-1 sm:grid-cols-2 items-center gap-4">
+          <!-- 左：リンク群 -->
+          <ul class="flex flex-wrap gap-x-6 gap-y-2 text-sm text-slate-500 w-full sm:w-auto justify-center sm:justify-start">
+            <li><%= link_to "利用規約", terms_path, class: "hover:underline" %></li>
+            <li><%= link_to "プライバシーポリシー", privacy_path, class: "hover:underline" %></li>
+            <li><%= link_to "アプリの使い方", help_path, class: "hover:underline" %></li>
+            <li><%= link_to "お問い合わせ", contact_path, class: "hover:underline" %></li>
+          </ul>
+
+          <!-- 右：コピーライト -->
+          <p class="text-xs text-slate-400 text-center sm:text-right w-full sm:w-auto">
+            © <%= Time.current.year %> Rails Learning
+          </p>
+        </div>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -7,7 +7,7 @@
     <!-- タイトル（常時表示） -->
     <%= link_to root_path, class: "font-semibold text-center md:text-left flex items-center gap-2" do %>
       <%= heroicon "rocket-launch", variant: :outline, options: { class: "w-6 h-6" } %>
-      <span>RailsLearningTest</span>
+      <span>Rails Learning</span>
     <% end %>
 
     <!-- === グローバルナビ＋ハンバーガー（右寄せ） === -->

--- a/app/views/static_pages/help.html.erb
+++ b/app/views/static_pages/help.html.erb
@@ -1,19 +1,150 @@
 <!-- app/views/static_pages/help.html.erb -->
+<%# パンくず %>
 <% breadcrumb :root %>
 <% breadcrumb :help %>
 <%= render "shared/breadcrumbs" %>
 
 <% content_for :title, "ヘルプ" %>
-<h1 class="text-2xl font-bold mb-4">ヘルプ</h1>
-<section class="prose max-w-none">
-  <h2>使い方</h2>
-  <p>このサービスの基本操作や各機能の説明をまとめます。</p>
 
-  <h3>主な機能</h3>
-  <ul>
-    <li>Code Editor（実行・テーマ切替・初期データ）</li>
-    <li>Rails Books（目次・前後ページ）</li>
-    <li>PreCode / CodeLibrary（ランキング・いいね）</li>
-    <li>…など</li>
-  </ul>
-</section>
+<div class="mx-auto max-w-3xl space-y-10">
+  <!-- ページ見出し -->
+  <h1 class="text-2xl font-bold mb-2">🚀 RailsLearning の使い方</h1>
+  <hr class="border-slate-200">
+
+  <!-- Code Editor -->
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">📝 Code Editor（コードエディタ）</h2>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">💡 概要</p>
+      <p class="mt-1">
+        アプリ上で Ruby や Rails のコードを入力・実行できる機能です。学習した内容をすぐに試し、その場で結果を確認できます。
+      </p>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">🔧 主な使い方</p>
+      <ol class="list-decimal ml-6 space-y-1 mt-1">
+        <li>「初期データ」プルダウンからサンプルコードを選択できます。</li>
+        <li>エディタ欄に自由にコードを入力してください。</li>
+        <li>▶ <span class="font-semibold">実行</span> ボタンを押すと、下部に実行結果が表示されます。</li>
+        <li>テーマ切替ボタンで、ダーク／ライトモードを切り替えられます。</li>
+      </ol>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">👀 ポイント</p>
+      <ul class="list-disc ml-6 space-y-1 mt-1">
+        <li>学習中のコード断片を気軽に試す場として利用してください。</li>
+        <li>保存はされないため、成果を残したい場合は PreCode 機能の利用がおすすめです。</li>
+      </ul>
+    </div>
+  </section>
+
+  <hr class="border-slate-200">
+
+  <!-- PreCode -->
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">📦 PreCode（プリコード）</h2>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">💡 概要</p>
+      <p class="mt-1">
+        「自分専用のコード断片（スニペット）」を保存できる機能です。頻繁に使うコードや学習メモを整理して残せます。簡単な Ruby の問題を作ることもできます。
+      </p>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">🔧 主な使い方</p>
+      <ol class="list-decimal ml-6 space-y-1 mt-1">
+        <li>右上の「新規作成」から PreCode を登録します。</li>
+        <li><span class="font-semibold">タイトル</span>、<span class="font-semibold">説明</span>（用途や補足）、<span class="font-semibold">コード本体</span>を入力します。</li>
+        <li>保存後は一覧に追加され、クリックで詳細を確認できます。</li>
+        <li>編集・削除も可能です。</li>
+      </ol>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">👀 ポイント</p>
+      <ul class="list-disc ml-6 space-y-1 mt-1">
+        <li>学習メモやよく使う処理の記録に最適です。</li>
+        <li>自動リサイズフォーム＋残り文字数カウンタで、長文でも扱いやすくなっています。</li>
+      </ul>
+    </div>
+  </section>
+
+  <hr class="border-slate-200">
+
+  <!-- Code Library -->
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">📚 Code Library（コードライブラリ）</h2>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">💡 概要</p>
+      <p class="mt-1">
+        ユーザーが作成した PreCode を「共有ライブラリ」として一覧・検索できる機能です。他人のコードを参考にしたり、人気コードを学習に活かせます。
+      </p>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">🔧 主な使い方</p>
+      <ol class="list-decimal ml-6 space-y-1 mt-1">
+        <li>検索フォームからタイトルや説明でコードを検索できます。</li>
+        <li>並び替えで「人気順」「利用数順」「新着順」を切り替えられます。</li>
+        <li>各コードページでは「いいね ❤️」や「使った 🧰」を押してリアクションできます。</li>
+      </ol>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">👀 ポイント</p>
+      <ul class="list-disc ml-6 space-y-1 mt-1">
+        <li>学習仲間がどんなコードを使っているか参考にできます。</li>
+        <li>自分のコードが他の人に使われるとモチベーションUPにつながります。</li>
+      </ul>
+    </div>
+  </section>
+
+  <hr class="border-slate-200">
+
+  <!-- Rails Books -->
+  <section class="space-y-4">
+    <h2 class="text-xl font-semibold">📖 Rails Books（Railsテキスト）</h2>
+
+    <div class="space-y-2">
+      <p class="text-sm font-semibold text-slate-500">💡 概要</p>
+      <p>
+        Rails の基礎から応用を体系的に学べる教材ページです。章ごとに整理されており、目次から順番に読み進められます。
+      </p>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">🔧 主な使い方</p>
+      <ol class="list-decimal ml-6 space-y-1 mt-1">
+        <li>書籍一覧ページから教材を選びます。</li>
+        <li>各書籍には <span class="font-semibold">章の一覧（目次）</span> があり、クリックで内容を閲覧できます。</li>
+        <li>章ページでは本文を読み進めながら、前後の章に移動できます。</li>
+      </ol>
+    </div>
+
+    <div>
+      <p class="text-sm font-semibold text-slate-500">👀 ポイント</p>
+      <ul class="list-disc ml-6 space-y-1 mt-1">
+        <li>一部の章には「FREE」ラベルがあり、無料で閲覧可能です。</li>
+        <li>基礎から体系的に進められるため、カリキュラム学習の補助にも使えます。</li>
+      </ul>
+    </div>
+  </section>
+
+  <hr class="border-slate-200">
+
+  <!-- まとめ -->
+  <section class="space-y-2">
+    <h2 class="text-xl font-semibold">✅ まとめ</h2>
+    <ul class="list-disc ml-6 space-y-1">
+      <li><span class="font-semibold">Code Editor</span>：その場でコードを実行</li>
+      <li><span class="font-semibold">PreCode</span>：自分のコードメモを保存</li>
+      <li><span class="font-semibold">Code Library</span>：共有ライブラリで学び合い</li>
+      <li><span class="font-semibold">Rails Books</span>：体系的な教材で学習</li>
+    </ul>
+  </section>
+</div>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -4,10 +4,112 @@
 <%= render "shared/breadcrumbs" %>
 
 <% content_for :title, "プライバシーポリシー" %>
-<h1 class="text-2xl font-bold mb-4">プライバシーポリシー</h1>
-<section class="prose max-w-none">
-  <h2>個人情報の利用目的</h2>
-  <p>…</p>
-  <h2>アクセス解析・Cookie</h2>
-  <p>…</p>
-</section>
+
+<div class="mx-auto max-w-3xl">
+  <h1 class="text-2xl font-bold mb-6">プライバシーポリシー</h1>
+
+  <div class="space-y-6 text-slate-700">
+    <div>
+      <p>
+        本プライバシーポリシー（以下、「本ポリシー」といいます。）は、当サービスが取得するユーザーの情報とその取扱いについて定めるものです。<br>
+        ユーザーの皆さまは、本ポリシーに同意のうえ本サービスをご利用ください。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">1. 取得する情報</h2>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>アカウント情報（氏名・ニックネーム、メールアドレス 等）</li>
+        <li>利用状況に関する情報（アクセス日時、閲覧ページ、検索条件、端末情報、IPアドレス 等）</li>
+        <li>お問い合わせ時に入力いただく情報</li>
+        <li>Cookie 等の識別子・広告識別子</li>
+      </ul>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">2. 利用目的</h2>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>本サービスの提供・維持・保護および改善のため</li>
+        <li>利用状況の把握、機能改善や新機能開発のための分析のため</li>
+        <li>不正利用の防止、セキュリティ対策のため</li>
+        <li>問い合わせ対応・重要なお知らせの連絡のため</li>
+        <li>法令・規約等に基づく対応のため</li>
+      </ul>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">3. 取得方法</h2>
+      <p>
+        ユーザーの入力による取得のほか、アクセス解析ツールや Cookie 等を用いて自動的に取得する場合があります。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">4. Cookie・アクセス解析</h2>
+      <p>
+        本サービスでは、利便性向上・利用状況の把握のために Cookie 等の技術を使用することがあります。<br>
+        ブラウザ設定により Cookie の受け入れを拒否できますが、サービスの一部機能が利用できない場合があります。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">5. 第三者提供</h2>
+      <p>
+        当社は、次の場合を除き、本人の同意なく個人情報を第三者に提供しません。<br>
+      </p>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>法令に基づく場合</li>
+        <li>人の生命・身体または財産の保護のために必要がある場合</li>
+        <li>業務委託先に取り扱いを委託する場合（委託先は適切に監督します）</li>
+      </ul>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">6. 外部送信・委託</h2>
+      <p>
+        本サービスの運営にあたり、サーバ運用やアクセス解析等を外部事業者へ委託し、必要な範囲で情報が送信されることがあります。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">7. 安全管理措置</h2>
+      <p>
+        取得した情報は、アクセス制御・暗号化・ログ監査等、適切な安全管理措置を講じて取り扱います。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">8. 開示・訂正・利用停止等の請求</h2>
+      <p>
+        ユーザーは、当社所定の手続により、自己の個人情報の開示・訂正・利用停止等を請求できます。<br>
+        具体的な手続は「お問い合わせ」よりご連絡ください。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">9. 未成年者の利用</h2>
+      <p>
+        未成年の方が本サービスを利用する場合、親権者等の同意を得た上でご利用ください。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">10. ポリシーの変更</h2>
+      <p>
+        本ポリシーの内容は、法令の改正やサービス内容の変更等により、事前の予告なく変更されることがあります。<br>
+        変更後のポリシーは、本サービス上に掲示した時点から効力を生じます。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">11. お問い合わせ</h2>
+      <p>
+        本ポリシーに関するお問い合わせは、本サービス内の連絡手段よりご連絡ください。
+      </p>
+    </div>
+
+    <div class="text-xs text-slate-500">
+      最終更新日：<%= Date.today.strftime("%Y-%m-%d") %>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -4,10 +4,68 @@
 <%= render "shared/breadcrumbs" %>
 
 <% content_for :title, "利用規約" %>
-<h1 class="text-2xl font-bold mb-4">利用規約</h1>
-<section class="prose max-w-none">
-  <h2>第1条 適用</h2>
-  <p>…（後で本番文面に差し替え）</p>
-  <h2>第2条 禁止事項</h2>
-  <ul><li>…</li></ul>
-</section>
+
+<div class="mx-auto max-w-3xl">
+  <h1 class="text-2xl font-bold mb-6">利用規約</h1>
+
+  <div class="space-y-6 text-slate-700">
+    <p>
+      この利用規約（以下、「本規約」といいます。）は、当サービスの利用条件を定めるものです。<br>
+      ユーザーの皆さまには、本規約に従って本サービスをご利用いただきます。
+    </p>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">第1条（適用）</h2>
+      <p>
+        本規約は、ユーザーと当サービス運営者との間の本サービス利用に関わる一切の関係に適用されるものとします。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">第2条（禁止事項）</h2>
+      <p>ユーザーは、本サービスの利用にあたり、以下の行為をしてはなりません。</p>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>法令または公序良俗に違反する行為</li>
+        <li>犯罪行為に関連する行為</li>
+        <li>本サービスの運営を妨害する行為</li>
+        <li>不正アクセスや不正な操作を試みる行為</li>
+        <li>その他、運営者が不適切と判断する行為</li>
+      </ul>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">第3条（サービスの提供の停止等）</h2>
+      <p>
+        運営者は、以下のいずれかに該当すると判断した場合、ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止することができます。
+      </p>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>システム保守や更新を行う場合</li>
+        <li>地震、火災、停電、天災地変など不可抗力によりサービス提供が困難な場合</li>
+        <li>その他、運営者がサービス提供を困難と判断した場合</li>
+      </ul>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">第4条（免責事項）</h2>
+      <p>
+        運営者は、本サービスの内容の変更、中断、終了によってユーザーに生じた損害について、一切の責任を負わないものとします。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">第5条（規約の変更）</h2>
+      <p>
+        運営者は、必要と判断した場合には、本規約を変更することができます。<br>
+        変更後の利用規約は、本サービスに掲載した時点で効力を生じるものとします。
+      </p>
+    </div>
+
+    <div>
+      <h2 class="font-semibold text-lg mb-2">第6条（準拠法・裁判管轄）</h2>
+      <p>
+        本規約の解釈には、日本法を準拠法とします。<br>
+        本サービスに関して紛争が生じた場合には、運営者の所在地を管轄する裁判所を専属的合意管轄とします。
+      </p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
### 概要
静的ページを整備し、フッターを常に最下部に固定して可読性を向上。

**作業内容**

- 使い方（ヘルプ）を追加：Editor/PreCode/Library/Books の説明を段落・箇条書きで作成
- 利用規約・プライバシーポリシーの暫定文面を作成し、mx-auto max-w-3xl で整形
- application.html.erb を整理：body min-h-screen flex-col＋main flex-1、内側ラッパに幅クラス集約
- フッターをグリッド化（リンク群＋コピーライト）し、全ページでの表示崩れを解消
- パンくず／タイトル反映、軽微なスタイル調整（余白・区切り線）