### PR TITLE
ヘッダーのハンバーガーをlg未満で常時表示に変更（md〜lgの空白状態を解消）

### DIFF
--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -31,7 +31,7 @@
 
       <!-- ハンバーガー：モバイルで表示 -->
       <button
-        class="p-2 rounded-lg hover:bg-slate-100 md:hidden lg:block"
+        class="p-2 rounded-lg hover:bg-slate-100 lg:block"
         data-action="click->modal#open"
         aria-label="メニューを開く">
         <%= heroicon "bars-3", options: { class: "w-6 h-6 text-slate-500" } %>


### PR DESCRIPTION
### 概要
md〜lg幅でヘッダーのメニューが消える問題を修正。

**作業内容**

- ハンバーガーの表示条件から md:hidden を削除