### PR TITLE
MVP指摘対応：ログイン導線の追加／エラーメッセージ日本語化／CodeLibraryのlikes・used_codesをTurbo対応

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,12 +1,14 @@
 # app/controllers/likes_controller.rb
 class LikesController < ApplicationController
   before_action :require_login!
+  before_action :set_pre_code, only: [ :create, :destroy ]
 
   def create
-    @pre_code = PreCode.find(params[:pre_code_id])
-    return head :forbidden if @pre_code.user_id == current_user.id  # 自分の投稿は弾く
-    Like.create!(user: current_user, pre_code: @pre_code)
+    return head :forbidden if @pre_code.user_id == current_user.id
 
+    current_user.likes.create!(pre_code: @pre_code)
+
+    @pre_code.reload
     respond_to do |f|
       f.turbo_stream
       f.html { redirect_back fallback_location: code_libraries_path }
@@ -18,10 +20,24 @@ class LikesController < ApplicationController
   def destroy
     like = current_user.likes.find(params[:id])
     @pre_code = like.pre_code
-    like.destroy
+    like.destroy!
+
+    @pre_code.reload
     respond_to do |f|
       f.turbo_stream
       f.html { redirect_back fallback_location: code_libraries_path }
     end
+  end
+
+  private
+
+  def set_pre_code
+    @pre_code =
+      if params[:pre_code_id].present?
+        PreCode.find(params[:pre_code_id])
+      else
+        # destroy 時は :id から like をたどるケースもあるため保険
+        current_user.likes.find(params[:id]).pre_code
+      end
   end
 end

--- a/app/controllers/used_codes_controller.rb
+++ b/app/controllers/used_codes_controller.rb
@@ -1,17 +1,29 @@
 # app/controllers/used_codes_controller.rb
 class UsedCodesController < ApplicationController
   before_action :require_login!
+  before_action :set_pre_code, only: :create
 
   def create
-    @pre_code = PreCode.find(params[:pre_code_id])
-    return head :forbidden if @pre_code.user_id == current_user.id  # 自分の投稿は弾く
+    # 自分の投稿は弾く
+    return head :forbidden if @pre_code.user_id == current_user.id
+
+    # 1ユーザー1レコード
     UsedCode.find_or_create_by!(user: current_user, pre_code: @pre_code) do |uc|
       uc.used_at = Time.current
     end
+
+    # 表示用に最新値へリロード
+    @pre_code.reload
 
     respond_to do |f|
       f.turbo_stream
       f.html { redirect_back fallback_location: code_libraries_path }
     end
+  end
+
+  private
+
+  def set_pre_code
+    @pre_code = PreCode.find(params[:pre_code_id])
   end
 end

--- a/app/views/code_libraries/_metrics.html.erb
+++ b/app/views/code_libraries/_metrics.html.erb
@@ -1,0 +1,11 @@
+<%# 右側アイコン＋カウンタ（置換対象） %>
+<div id="<%= dom_id(pre_code, :metrics) %>" class="text-sm text-slate-500 shrink-0">
+  <span class="inline-flex items-center gap-1 mr-4 align-middle">
+    <%= heroicon "heart",  variant: :solid,   options: { class: "w-4 h-4" } %>
+    <%= pre_code.like_count %>
+  </span>
+  <span class="inline-flex items-center gap-1 align-middle">
+    <%= heroicon "briefcase", variant: :outline, options: { class: "w-4 h-4" } %>
+    <%= pre_code.use_count %>
+  </span>
+</div>

--- a/app/views/code_libraries/index.html.erb
+++ b/app/views/code_libraries/index.html.erb
@@ -45,16 +45,7 @@
           <% end %>
 
           <!-- 右側：メトリクスやボタン（リンクの外） -->
-          <div class="text-sm text-slate-500 shrink-0">
-            <span class="inline-flex items-center gap-1 mr-4 align-middle">
-              <%= heroicon "heart", variant: :solid, options: { class: "w-4 h-4" } %>
-              <%= pc.like_count %>
-            </span>
-            <span class="inline-flex items-center gap-1 align-middle">
-              <%= heroicon "briefcase", variant: :outline, options: { class: "w-4 h-4" } %>
-              <%= pc.use_count %>
-            </span>
-          </div>
+          <%= render "metrics", pre_code: pc %>
         </div>
 
         <div class="mt-3">

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -4,3 +4,7 @@
         pre_code: @pre_code,
         current_like: current_user.likes.find_by(pre_code_id: @pre_code.id) %>
 <% end %>
+
+<%= turbo_stream.replace dom_id(@pre_code, :metrics) do %>
+  <%= render "code_libraries/metrics", pre_code: @pre_code %>
+<% end %>

--- a/app/views/likes/destroy.turbo_stream.erb
+++ b/app/views/likes/destroy.turbo_stream.erb
@@ -4,3 +4,7 @@
         pre_code: @pre_code,
         current_like: current_user.likes.find_by(pre_code_id: @pre_code.id) %>
 <% end %>
+
+<%= turbo_stream.replace dom_id(@pre_code, :metrics) do %>
+  <%= render "code_libraries/metrics", pre_code: @pre_code %>
+<% end %>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,22 +1,28 @@
 <% content_for :title, "パスワード再設定" %>
-<h1 class="text-xl font-semibold mb-4">新しいパスワードを設定</h1>
 
-<%= form_with model: @user,
-              url: password_reset_path(params[:id]),
-              method: :patch,
-              class: "space-y-4" do |f| %>
-  <%= render "shared/errors", model: @user %>
+<div class="flex justify-center items-center min-h-screen bg-slate-50 px-4">
+  <div class="w-full max-w-md bg-white shadow-md rounded-lg p-6 space-y-6">
 
-  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-    <div>
-      <%= f.label :password, "新しいパスワード", class: "block text-sm mb-1" %>
-      <%= f.password_field :password, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
-    </div>
-    <div>
-      <%= f.label :password_confirmation, "確認用パスワード", class: "block text-sm mb-1" %>
-      <%= f.password_field :password_confirmation, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
-    </div>
+    <h1 class="text-xl font-semibold mb-4 text-center">パスワード再設定</h1>
+
+    <p class="text-sm text-gray-600 text-center">
+      再設定したいパスワードを入力してください。
+    </p>
+
+    <%= form_with model: @user, url: password_reset_path(params[:id]), method: :patch, class: "space-y-4 pb-2" do |f| %>
+      <%= render "shared/errors", model: @user %>
+
+      <div>
+        <%= f.label :password, "パスワード", class: "block text-sm mb-1" %>
+        <%= f.password_field :password, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500", placeholder: "8文字以上 20文字未満" %>
+      </div>
+
+      <div>
+        <%= f.label :password_confirmation, "パスワード確認", class: "block text-sm mb-1" %>
+        <%= f.password_field :password_confirmation, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500", placeholder: "8文字以上 20文字未満" %>
+      </div>
+
+      <%= f.submit "送信", class: "w-full bg-slate-900 text-white py-2 rounded-xl hover:bg-slate-800" %>
+    <% end %>
   </div>
-
-  <%= f.submit "更新する", class: "rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800" %>
-<% end %>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,15 +1,29 @@
 <% content_for :title, "パスワード再設定" %>
-<h1 class="text-xl font-semibold mb-4">パスワード再設定メールを送る</h1>
 
-<%= form_with url: password_resets_path, scope: nil, class: "space-y-4" do |f| %>
-  <div>
-    <label class="block text-sm mb-1" for="email">登録メールアドレス</label>
-    <input
-      type="email" name="email" id="email"
-      class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500"
-      placeholder="you@example.com" />
+<div class="flex justify-center items-center min-h-screen bg-slate-50 px-4">
+  <div class="w-full max-w-md bg-white shadow-md rounded-lg p-6 space-y-6">
+
+    <h1 class="text-xl font-semibold mb-4 text-center">パスワードをお忘れの方</h1>
+
+    <p class="text-sm text-gray-600 text-center">
+      登録したメールアドレスを入力してください。<br>
+      パスワードリセット用のリンクを送信します。
+    </p>
+
+    <%= form_with url: password_resets_path, scope: nil, class: "space-y-4" do |f| %>
+      <div>
+        <label class="block text-sm mb-1" for="email">メールアドレス</label>
+        <input type="email" name="email" id="email"
+          class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500"
+          placeholder="メールアドレスを入力してください" />
+      </div>
+
+      <%= f.submit "送信", class: "w-full bg-slate-900 text-white py-2 rounded-xl hover:bg-slate-800" %>
+    <% end %>
+
+    <div class="text-center">
+      <%= link_to "ログインページに戻る", new_session_path, class: "text-sm text-slate-600 hover:underline" %>
+    </div>
+
   </div>
-
-  <%= f.submit "送信する",
-        class: "rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800" %>
-<% end %>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,25 +1,39 @@
 <% content_for :title, "ログイン" %>
-<h1 class="text-xl font-semibold mb-4">ログイン</h1>
 
-<%= form_with url: session_path, scope: nil, class: "space-y-4" do |f| %>
-  <div>
-    <label class="block text-sm mb-1" for="email">メールアドレス</label>
-    <input type="email" name="email" id="email"
-           class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" />
-  </div>
+<div class="flex justify-center items-center min-h-screen bg-slate-50 px-4">
+  <div class="w-full max-w-md bg-white shadow-md rounded-lg p-6 space-y-6">
+    <h1 class="text-2xl font-bold text-center">ログイン</h1>
 
-  <div>
-    <label class="block text-sm mb-1" for="password">パスワード</label>
-    <input type="password" name="password" id="password"
-           class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" />
-  </div>
+    <%= form_with url: session_path, scope: nil, class: "space-y-4" do |f| %>
+      <div>
+        <label class="block text-sm mb-1" for="email">メールアドレス</label>
+        <input type="email" name="email" id="email" class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" />
+      </div>
 
-  <div class="flex items-center gap-3">
-    <%= f.submit "ログイン", class: "rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800" %>
-    <%= link_to "パスワードをお忘れですか？", new_password_reset_path, class: "text-sm text-slate-500 hover:underline" %>
-  </div>
+      <div>
+        <label class="block text-sm mb-1" for="password">パスワード</label>
+        <input type="password" name="password" id="password" class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" />
+      </div>
 
-  <div class="mt-6">
-    <%= render "shared/oauth_buttons" %>
+      <%= f.submit "ログイン", class: "w-full bg-slate-900 text-white py-2 rounded-xl hover:bg-slate-800" %>
+    <% end %>
+
+    <div class="flex justify-between text-sm text-slate-600">
+      <%= link_to "パスワード再設定", new_password_reset_path, class: "hover:underline" %>
+      <%= link_to "新規登録", new_user_path, class: "hover:underline" %>
+    </div>
+
+    <div class="relative my-4">
+      <div class="absolute inset-0 flex items-center">
+        <div class="w-full border-t border-gray-300"></div>
+      </div>
+      <div class="relative flex justify-center text-sm">
+        <span class="bg-white px-2 text-gray-500">または</span>
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <%= render "shared/oauth_buttons" %>
+    </div>
   </div>
-<% end %>
+</div>

--- a/app/views/used_codes/create.turbo_stream.erb
+++ b/app/views/used_codes/create.turbo_stream.erb
@@ -4,3 +4,7 @@
         pre_code: @pre_code,
         current_like: current_user.likes.find_by(pre_code_id: @pre_code.id) %>
 <% end %>
+
+<%= turbo_stream.replace dom_id(@pre_code, :metrics) do %>
+  <%= render "code_libraries/metrics", pre_code: @pre_code %>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,36 +1,50 @@
 <% content_for :title, "新規登録" %>
-<h1 class="text-xl font-semibold mb-4">新規登録</h1>
 
-<%= form_with model: @user, url: users_path, class: "space-y-4" do |f| %>
-  <%= render "shared/errors", model: @user %>
+<div class="flex justify-center items-center min-h-screen bg-slate-50 px-4">
+  <div class="w-full max-w-md bg-white shadow-md rounded-lg p-6 space-y-6">
 
-  <div>
-    <%= f.label :name, "名前", class: "block text-sm mb-1" %>
-    <%= f.text_field :name, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
-  </div>
+    <h1 class="text-2xl font-bold text-center">新規登録</h1>
 
-  <div>
-    <%= f.label :email, "メールアドレス", class: "block text-sm mb-1" %>
-    <%= f.email_field :email, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
-  </div>
+    <%= form_with model: @user, url: users_path, class: "space-y-4" do |f| %>
+      <div>
+        <%= f.label :name, "ユーザー名", class: "block text-sm mb-1" %>
+        <%= f.text_field :name, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
+      </div>
 
-  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-    <div>
-      <%= f.label :password, "パスワード", class: "block text-sm mb-1" %>
-      <%= f.password_field :password, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
+      <div>
+        <%= f.label :email, "メールアドレス", class: "block text-sm mb-1" %>
+        <%= f.email_field :email, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
+      </div>
+
+      <div>
+        <%= f.label :password, "パスワード", class: "block text-sm mb-1" %>
+        <%= f.password_field :password, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
+      </div>
+
+      <div>
+        <%= f.label :password_confirmation, "パスワード確認", class: "block text-sm mb-1" %>
+        <%= f.password_field :password_confirmation, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
+      </div>
+
+      <%= f.submit "新規登録", class: "w-full bg-slate-900 text-white py-2 rounded-xl hover:bg-slate-800" %>
+    <% end %>
+
+    <div class="flex justify-end text-sm text-slate-600">
+      <%= link_to "ログインページへ", new_session_path, class: "hover:underline" %>
     </div>
-    <div>
-      <%= f.label :password_confirmation, "確認用パスワード", class: "block text-sm mb-1" %>
-      <%= f.password_field :password_confirmation, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
+
+    <div class="relative my-4">
+      <div class="absolute inset-0 flex items-center">
+        <div class="w-full border-t border-gray-300"></div>
+      </div>
+      <div class="relative flex justify-center text-sm">
+        <span class="bg-white px-2 text-gray-500">または</span>
+      </div>
     </div>
-  </div>
 
-  <div class="flex items-center gap-3">
-    <%= f.submit "登録する", class: "rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800" %>
-    <%= link_to "ログインページへ", new_session_path, class: "text-sm text-slate-500 hover:underline" %>
-  </div>
+    <div class="space-y-2">
+      <%= render "shared/oauth_buttons" %>
+    </div>
 
-  <div class="mt-6">
-    <%= render "shared/oauth_buttons" %>
   </div>
-<% end %>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,8 +19,16 @@ ja:
         heading: "見出し"
         content: "本文"
         images: "画像（複数可）"
+      pre_code:
+        title: "タイトル"
+        body: "コードの説明"
+    models:
+      pre_code: "PreCode"
   helpers:
     submit:
       book_section:
         create: "作成する"
         update: "更新する"
+  errors:
+    messages:
+      blank: "を入力してください"

--- a/spec/requests/likes_spec.rb
+++ b/spec/requests/likes_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 
 RSpec.describe "Likes", type: :request do
   let(:user)     { create(:user, password: "secret123", password_confirmation: "secret123") }
-  let(:pre_code) { create(:pre_code) }
+  let(:author)   { create(:user, password: "secret123", password_confirmation: "secret123") }
+  let(:pre_code) { create(:pre_code, user: author) }
 
   describe "認可" do
     it "未ログインは作成にアクセスできずリダイレクト" do
@@ -21,7 +22,7 @@ RSpec.describe "Likes", type: :request do
       }.to change(Like, :count).by(1)
        .and change { pre_code.reload.like_count }.by(1)
 
-      # Turbo Stream or リダイレクトのどちらでも許容
+      # Turbo Stream / リダイレクトのどちらでも許容
       expect(response).to have_http_status(:ok).or have_http_status(:found)
     end
 
@@ -39,10 +40,24 @@ RSpec.describe "Likes", type: :request do
         delete like_path(like)
       }.to change(Like, :count).by(-1)
        .and change { pre_code.reload.like_count }.by(-1)
+
       expect(response).to have_http_status(:ok).or have_http_status(:found)
     end
 
-    it "他人の Like は削除できず 404（RecordNotFound → 404 rescue）" do
+    # === ここを追加 ===
+    it "自分の投稿にはいいねできず :forbidden で件数も増えない" do
+      my_pre_code = create(:pre_code, user: user)
+      expect {
+        post likes_path, params: { pre_code_id: my_pre_code.id }
+      }.not_to change(Like, :count)
+      expect(my_pre_code.reload.like_count).to eq(0)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "削除ガード" do
+    it "他人の Like は削除できず 404" do
+      sign_in(user)
       other_like = create(:like, pre_code: pre_code) # 別ユーザー
       delete like_path(other_like)
       expect(response).to have_http_status(:not_found)

--- a/spec/requests/used_codes_spec.rb
+++ b/spec/requests/used_codes_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 
 RSpec.describe "UsedCodes", type: :request do
   let(:user)     { create(:user, password: "secret123", password_confirmation: "secret123") }
-  let(:pre_code) { create(:pre_code) }
+  let(:author)   { create(:user, password: "secret123", password_confirmation: "secret123") }
+  let(:pre_code) { create(:pre_code, user: author) }
 
   describe "認可" do
     it "未ログインは作成にアクセスできずリダイレクト" do
@@ -20,6 +21,7 @@ RSpec.describe "UsedCodes", type: :request do
         post used_codes_path, params: { pre_code_id: pre_code.id }
       }.to change(UsedCode, :count).by(1)
        .and change { pre_code.reload.use_count }.by(1)
+
       expect(response).to have_http_status(:ok).or have_http_status(:found)
     end
 
@@ -29,6 +31,16 @@ RSpec.describe "UsedCodes", type: :request do
         post used_codes_path, params: { pre_code_id: pre_code.id }
       }.not_to change(UsedCode, :count)
       expect(pre_code.reload.use_count).to eq(1)
+    end
+
+    # === ここを追加 ===
+    it "自分の投稿は利用記録を作れず :forbidden で件数も増えない" do
+      my_pre_code = create(:pre_code, user: user)
+      expect {
+        post used_codes_path, params: { pre_code_id: my_pre_code.id }
+      }.not_to change(UsedCode, :count)
+      expect(my_pre_code.reload.use_count).to eq(0)
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end


### PR DESCRIPTION
### 概要
MVPフィードバックの3点（導線・文言・非同期）をまとめて解消。

**作業内容**

- ログイン／新規登録／パスワード再設定画面に相互リンクを追加し導線を補強
- config/locales/ja.yml を拡充し、PreCode等の属性名・エラー文を日本語化
- CodeLibraryの右側メトリクスをパーシャル化（dom_id 付与）し置換ターゲットを定義
- Likes／UsedCodes の Turbo Stream テンプレートを実装し、actions と metrics を同時更新
- controllersを整理（自分の投稿は :forbidden、counter_cache反映のため @pre_code.reload ）