### PR TITLE
認証基盤をauthentications基準に移行しprovider分岐を撤去＋emailグローバル一意インデックス追加

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -25,3 +25,11 @@
 
 /* Quill のコードブロック用クラス */
 .content-body pre.ql-syntax { background: #0f172a; }
+
+/* content-body 内の <hr> を見やすく */
+.content-body hr {
+  border: 0;
+  border-top: 1px solid #e5e7eb; /* slate-200 */
+  margin: 1.25rem 0;             /* 上下余白 */
+  width: 100%;
+}

--- a/app/controllers/admin/book_sections_controller.rb
+++ b/app/controllers/admin/book_sections_controller.rb
@@ -77,10 +77,8 @@ class Admin::BookSectionsController < Admin::BaseController
   def sanitize_content(html)
     sanitize(
       html,
-      # 許可タグは用途に応じて調整。img を許可して DirectUpload の URL を通す
-      tags: %w[p h1 h2 h3 h4 h5 h6 b i u strong em a ul ol li pre code blockquote br span div img],
-      # href/src/class/rel/alt など最低限。必要なら loading / width / height 等を追加
-      attributes: %w[href class target rel src alt]
+      tags: %w[p h1 h2 h3 h4 h5 h6 b i u strong em a ul ol li pre code blockquote br span div img hr],
+      attributes: %w[href class target rel src alt style]
     )
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,3 @@
-# app/controllers/sessions_controller.rb
 class SessionsController < ApplicationController
   before_action :require_guest!,  only: %i[new create]
   before_action :require_login!,  only: %i[destroy]
@@ -9,8 +8,8 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:email])
 
-    # 通常ログイン（外部ログイン行は password を持たないので弾く）
-    if user&.provider.blank? && user&.authenticate(params[:password])
+    # 通常ログイン：外部連携アカウント（authenticationsあり）はパスワード不要/不可
+    if user&.uses_password? && user&.authenticate(params[:password])
       reset_session
       session[:user_id] = user.id
       redirect_to root_path, notice: "ログインしました"

--- a/app/helpers/sections_helper.rb
+++ b/app/helpers/sections_helper.rb
@@ -1,13 +1,12 @@
-# app/helpers/sections_helper.rb
 module SectionsHelper
   # BookSection の本文を安全に表示（表示側の二重防御）
   # 必要なタグ/属性は用途に応じて調整
   def render_section_content(section)
     allowed_tags  = %w[
-      p pre code h1 h2 h3 h4 h5 h6 b i u strong em a ul ol li br blockquote span div img
+      p pre code h1 h2 h3 h4 h5 h6 b i u strong em a ul ol li br blockquote span div img hr
     ]
     # 画像表示に必要な属性を許可（最小限）
-    allowed_attrs = %w[href class rel target src alt loading width height]
+    allowed_attrs = %w[href class rel target src alt loading width height style]
 
     sanitize(section.content.to_s, tags: allowed_tags, attributes: allowed_attrs)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,13 +1,13 @@
 # app/models/user.rb
 class User < ApplicationRecord
-  # bcrypt
-  has_secure_password validations: false
-
   # ---------- アソシエーション ----------
   has_many :pre_codes, dependent: :destroy
   has_many :likes,      dependent: :destroy
   has_many :used_codes, dependent: :destroy
   has_many :authentications, dependent: :destroy
+
+  # bcrypt
+  has_secure_password validations: false
 
   # ---------- 正規化 ----------
   before_validation :normalize_email
@@ -16,21 +16,15 @@ class User < ApplicationRecord
   # 共通
   validates :name, presence: true, length: { maximum: 50 }
 
-  # 通常ログイン（provider が空のとき）
+  # ★ 一意性は「パスワード方式 (= 外部連携なし)」の場合のみチェック
   validates :email,
     presence: true,
     length:  { maximum: 255 },
     format:  { with: URI::MailTo::EMAIL_REGEXP },
     uniqueness: { case_sensitive: false },
-    if: -> { provider.blank? }
+    if: :email_uniqueness_required?
 
   validates :password, presence: true, length: { minimum: 6 }, if: :password_required?
-
-  # 外部ログイン（provider があるとき）
-  with_options if: -> { provider.present? } do
-    validates :provider, presence: true
-    validates :uid,      presence: true
-  end
 
   # ---------- パスワード再設定 ----------
   def generate_reset_token!
@@ -49,20 +43,34 @@ class User < ApplicationRecord
     update!(reset_password_token: nil, reset_password_sent_at: nil)
   end
 
-  # ---------- OmniAuth ユーザー作成/取得 ----------
+  # --------- OmniAuth ユーザー作成/取得（authentications 経由） ----------
   # auth は OmniAuth::AuthHash 想定
   def self.find_or_create_from_omniauth(auth)
-    user = find_or_initialize_by(provider: auth.provider, uid: auth.uid)
+    authentication = Authentication.find_or_initialize_by(
+      provider: auth.provider, uid: auth.uid
+    )
 
-    # 名前・メール（GitHub等はメールが取れない場合あり）
-    user.name  ||= auth.dig(:info, :name).presence || auth.dig(:info, :nickname).presence || "User"
+    user = authentication.user ||
+           User.find_by(email: auth.dig(:info, :email)) ||
+           User.new
+
+    user.name  ||= auth.dig(:info, :name).presence ||
+                   auth.dig(:info, :nickname).presence || "User"
     user.email ||= auth.dig(:info, :email)
-
-    # パスワード未設定ならダミーを入れておく（has_secure_passwordの都合）
     user.password = SecureRandom.hex(16) if user.password_digest.blank?
-
     user.save!
+
+    if authentication.user_id != user.id
+      authentication.user = user
+      authentication.save!
+    end
+
     user
+  end
+
+  # 外部連携が無い (= authentications が空) ユーザーはパスワード方式を使う
+  def uses_password?
+    authentications.blank?
   end
 
   private
@@ -71,8 +79,13 @@ class User < ApplicationRecord
     self.email = email.to_s.strip.downcase.presence
   end
 
-  # 「通常ログイン」かつ「新規作成 or パスワードを入力しているとき」だけ必須
+  # 「通常ログイン (= 外部連携なし) で、新規作成 or パスワード入力があるとき」だけ必須
   def password_required?
-    provider.blank? && (new_record? || password.present?)
+    uses_password? && (new_record? || password.present?)
+  end
+
+  # ★ email 一意性チェックを実行するか
+  def email_uniqueness_required?
+    uses_password?
   end
 end

--- a/app/views/code_libraries/show.html.erb
+++ b/app/views/code_libraries/show.html.erb
@@ -54,7 +54,7 @@
                               redirect: editor_path(pre_code_id: @pre_code.id)),
               method: :post,
               form: { data: { turbo: false } },
-              class: "inline-flex justify-center w-64 md:w-80 lg:w-96
+              class: "inline-flex justify-center w-50 sm:w-64 md:w-80 lg:w-96
                       bg-[#CC0000] text-white px-4 py-2 rounded
                       hover:bg-[#BB0000] active:bg-[#AA0000]" %>
       </div>

--- a/db/migrate/20250903230349_swap_users_email_unique_index_to_global.rb
+++ b/db/migrate/20250903230349_swap_users_email_unique_index_to_global.rb
@@ -1,0 +1,25 @@
+class SwapUsersEmailUniqueIndexToGlobal < ActiveRecord::Migration[8.0]
+  # 部分インデックスを壊さず切り替えるため、トランザクション外で CONCURRENTLY を使う
+  disable_ddl_transaction!
+
+  NEW_INDEX = "index_users_on_lower_email_unique".freeze
+  OLD_INDEX = "index_users_on_email_unique_when_provider_is_null".freeze
+
+  def up
+    # ① 新: lower(email) に対するグローバル一意インデックスを追加
+    add_index :users, "lower(email)", unique: true,
+              name: NEW_INDEX, algorithm: :concurrently
+
+    # ② 旧: provider IS NULL の部分インデックスを削除
+    remove_index :users, name: OLD_INDEX, algorithm: :concurrently
+  end
+
+  def down
+    # 旧インデックスを復元（ロールバック用）
+    add_index :users, "lower((email))", unique: true,
+              where: "(provider IS NULL)",
+              name: OLD_INDEX, algorithm: :concurrently
+
+    remove_index :users, name: NEW_INDEX, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_01_103538) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_03_230349) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -131,7 +131,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_01_103538) do
     t.boolean "admin", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "lower((email)::text)", name: "index_users_on_email_unique_when_provider_is_null", unique: true, where: "(provider IS NULL)"
+    t.index "lower((email)::text)", name: "index_users_on_lower_email_unique", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token_unique", unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,35 +1,40 @@
 # spec/factories/users.rb
 FactoryBot.define do
-  # === 基本ユーザー（通常登録） ===
   factory :user do
-    name  { "Normal" }
-    sequence(:email) { |n| "normal#{n}@example.com" }
-    password              { "password" }
-    password_confirmation { "password" }
-    provider { nil }
-    uid      { nil }
-    admin    { false }
-  end
-
-  # === Google ログインユーザー（OAuth） ===
-  factory :google_user, class: "User" do
-    name  { "Google Taro" }
-    email { "taro@example.com" }
-    provider { "google_oauth2" }
-    uid      { "g-#{SecureRandom.hex(4)}" }
-    password              { nil }
-    password_confirmation { nil }
+    sequence(:name)  { |n| "User#{n}" }
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password              { "secret123" }
+    password_confirmation { "secret123" }
     admin { false }
   end
 
-  # === GitHub ログインユーザー（OAuth, 管理者想定） ===
-  factory :github_user, class: "User" do
-    name  { "Octo" }
-    email { "octo@example.com" }
-    provider { "github" }
-    uid      { "gh-#{SecureRandom.hex(4)}" }
+  # OAuthユーザー（Google）
+  factory :google_user, parent: :user do
+    # 「password不要」を満たす
     password              { nil }
     password_confirmation { nil }
+
+    # build時点でOAuth判定に入るようにする（createではなくbuild）
+    after(:build) do |user|
+      # has_many :authentications 前提（モデルに合わせて名称を変えてください）
+      user.authentications.build(
+        provider: "google_oauth2",
+        uid:      "uid-#{SecureRandom.hex(4)}"
+      )
+    end
+  end
+
+  # OAuthユーザー（GitHub, admin: true）
+  factory :github_user, parent: :user do
     admin { true }
+    password              { nil }
+    password_confirmation { nil }
+
+    after(:build) do |user|
+      user.authentications.build(
+        provider: "github",
+        uid:      "uid-#{SecureRandom.hex(4)}"
+      )
+    end
   end
 end

--- a/spec/requests/admin/authorization_smoke_spec.rb
+++ b/spec/requests/admin/authorization_smoke_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Admin Authorization", type: :request do
       end
 
       it "admin はアクセスできる" do
-        sign_in_as(admin)
+        sign_in_as(admin, password: "secret123")
         get public_send(path_helper)
         expect(response).to have_http_status(:ok)
       end

--- a/spec/requests/admin/book_sections_spec.rb
+++ b/spec/requests/admin/book_sections_spec.rb
@@ -2,10 +2,10 @@
 require "rails_helper"
 
 RSpec.describe "Admin::BookSections", type: :request do
-  let(:admin) { create(:user, admin: true) }
+  let(:admin) { create(:user, admin: true,  password: "secret123", password_confirmation: "secret123") }
   let(:book)  { create(:book) }
 
-  before { sign_in_as(admin) }
+  before { sign_in_as(admin, password: "secret123") }
 
   it "GET /admin/book_sections works" do
     get admin_book_sections_path

--- a/spec/requests/admin/books_spec.rb
+++ b/spec/requests/admin/books_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe "Admin::Books", type: :request do
   let(:admin) { create(:user, admin: true) }
 
-  before { sign_in_as(admin) }
+  before { sign_in_as(admin, password: "secret123") }
 
   it "GET /admin/books works" do
     get admin_books_path

--- a/spec/requests/admin/dashboards_spec.rb
+++ b/spec/requests/admin/dashboards_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Admin::Dashboards", type: :request do
   let(:admin) { create(:user, admin: true) }
 
   it "GET /admin returns 200 for admin" do
-    sign_in_as(admin)
+    sign_in_as(admin, password: "secret123")
     get admin_root_path
     expect(response).to have_http_status(:ok)
     expect(response.body).to include("Dashboard")


### PR DESCRIPTION
### 概要
認証をauthentications基準に変更し、provider分岐を撤去した。

**作業内容**

- SessionsController の provider依存ロジックを削除
- User モデルを修正し、uses_password? を追加
- OmniAuth処理を authentications 経由に変更
- users.email にグローバル一意インデックスを追加