### PR TITLE
MVP仕上げ：CodeLibraryのレスポンシブ化／Quill拡張／認証基盤のprovider撤去とemail一意化／BooksのFRE…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,9 @@ group :development do
 
   # N+1 クエリ検出・不要 eager load 警告（開発支援用）
   gem "bullet"
+
+  # letter_opener
+  gem "letter_opener_web"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -195,6 +197,17 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -509,6 +522,7 @@ DEPENDENCIES
   importmap-rails
   kamal
   kaminari
+  letter_opener_web
   mini_magick
   omniauth
   omniauth-github

--- a/app/controllers/book_sections_controller.rb
+++ b/app/controllers/book_sections_controller.rb
@@ -1,16 +1,34 @@
 class BookSectionsController < ApplicationController
   before_action :set_book
+  helper_method :logged_in?
 
   def show
     # ネストURLなので同一Book内に限定して安全に検索
     @section = @book.book_sections.find(params[:id])
-    @prev    = @section.previous
-    @next    = @section.next
+
+    # ★未ログインかつ FREE でなければログインへ
+    unless @section.is_free? || logged_in?
+      # 可能なら戻り先を保存（アプリに store_location があれば）
+      if respond_to?(:store_location, true)
+        store_location(book_section_path(@book, @section))
+      end
+      redirect_to(new_session_path, alert: "このページを表示するにはログインが必要です")
+      return
+    end
+
+    # 表示継続（前後リンク用）
+    @prev = @section.previous
+    @next = @section.next
   end
 
   private
 
   def set_book
     @book = Book.find(params[:book_id])
+  end
+
+  # アプリに既に同等のヘルパがあるなら不要。無ければ簡易版を用意。
+  def logged_in?
+    !!current_user
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -6,8 +6,7 @@ class PasswordResetsController < ApplicationController
   def new; end
 
   def create
-    # 通常ログインユーザー（= 外部連携が無いユーザー）のみ対象
-    user = User.where.missing(:authentications).find_by(email: params[:email])
+    user = User.find_by(email: params[:email])
 
     if user
       user.generate_reset_token!
@@ -32,7 +31,7 @@ class PasswordResetsController < ApplicationController
     end
 
     # 通常ログインユーザーとして更新（外部ログインは対象外）
-    if @user.uses_password? && @user.update(password_params)
+    if @user.update(password_params)
       @user.clear_reset_token!
       redirect_to new_session_path, notice: "パスワードを更新しました。ログインしてください"
     else

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,15 +36,15 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
   # Make template changes take effect immediately.
   config.action_mailer.perform_caching = false
 
-  # Set localhost to be used by links generated in mailer templates.
-  config.action_mailer.delivery_method = :test
-  config.action_mailer.perform_deliveries = false
+  # 開発では画面でメール内容を確認
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+
+  # メール内URL用のホスト
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   # Print deprecation notices to the Rails logger.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,11 @@ Rails.application.routes.draw do
     resources :book_sections, except: %i[show]
   end
 
+  # letter_opener
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
+
   # OmniAuth
   get "/auth/:provider", to: "omni_auth#passthru", as: :auth,
                          constraints: { provider: /(google_oauth2|github)/ }


### PR DESCRIPTION
### 概要
MVP完成に向けて UI・編集・認証・公開範囲・テストを横断的に整備しました。

**作業内容**

- Code Library詳細をレスポンシブ化、操作ボタンの配置最適化
- Quillエディタ拡張（画像直アップロード・区切り線・色/背景）＋保存前/表示時サニタイズ強化
- 認証をauthentications基準へ移行：emailグローバル一意化、旧provider/uidと関連Indexを削除、PWリセット/セッション周りを更新
- BooksにFREE機能を追加：未ログインでもFREEセクション閲覧可、非FREEはログインに誘導
- RSpec/Factoryを全面更新（FREE/画像添付/OmniAuth/Like・UsedCode/Guard等）と細かなスタイル調整