### PR TITLE
Booksにpositionを追加して章番号順で並ぶよう変更（管理入力・検証・既存採番・RSpec対応）

### DIFF
--- a/app/controllers/admin/books_controller.rb
+++ b/app/controllers/admin/books_controller.rb
@@ -2,7 +2,7 @@ class Admin::BooksController < Admin::BaseController
   layout "admin"
 
   def index
-    @books = Book.order(updated_at: :desc).page(params[:page])
+    @books = Book.order(position: :asc, updated_at: :desc).page(params[:page])
   end
 
   def new
@@ -38,6 +38,6 @@ class Admin::BooksController < Admin::BaseController
 
   private
   def book_params
-    params.require(:book).permit(:title, :description)
+    params.require(:book).permit(:title, :description, :position)
   end
 end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -5,7 +5,7 @@ class BooksController < ApplicationController
     @books = Book
       .select(:id, :title, :description, :updated_at, :book_sections_count)
       .includes(:book_sections)                # N+1回避
-      .order(updated_at: :desc)
+      .order(position: :asc, updated_at: :desc)
       .page(params[:page])
   end
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -4,4 +4,18 @@ class Book < ApplicationRecord
 
   validates :title,       presence: true, length: { maximum: 100 }
   validates :description, presence: true, length: { maximum: 500 }
+
+  # 並び順
+  validates :position,
+           presence: true,
+           numericality: { only_integer: true, greater_than: 0 },
+           uniqueness: true   # 重複時にエラー表示（DBのuniqueと二重で守る）
+
+  before_validation :set_default_position, on: :create
+
+  private
+
+  def set_default_position
+    self.position ||= (Book.maximum(:position) || 0) + 1
+  end
 end

--- a/app/views/admin/books/_form.html.erb
+++ b/app/views/admin/books/_form.html.erb
@@ -1,3 +1,4 @@
+<!-- app/views/admin/books/_form.html.erb -->
 <%= form_with model: @book, url: (@book.new_record? ? admin_books_path : admin_book_path(@book)),
               method: (@book.new_record? ? :post : :patch),
               class: "space-y-4" do |f| %>
@@ -23,9 +24,16 @@
     <%= f.text_area :description, rows: 5, class: "w-full rounded border px-3 py-2" %>
   </div>
 
+  <div>
+    <%= f.label :position, "並び順（章番号）", class: "block text-sm text-slate-600" %>
+    <%= f.number_field :position, min: 1, step: 1, class: "w-full max-w-40 rounded border px-3 py-2" %>
+    <p class="mt-1 text-xs text-slate-500">1, 2, 3… の昇順で表示されます（重複不可）。</p>
+  </div>
+
   <div class="flex gap-2">
     <%= f.submit (@book.new_record? ? "作成する" : "更新する"),
-        class: "px-4 py-2 rounded bg-slate-900 text-white" %>
-    <%= link_to "一覧に戻る", admin_books_path, class: "px-4 py-2 rounded ring-1 ring-slate-300" %>
+                 class: "px-4 py-2 rounded bg-slate-900 text-white" %>
+    <%= link_to "一覧に戻る", admin_books_path,
+                class: "px-4 py-2 rounded ring-1 ring-slate-300" %>
   </div>
 <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,12 +5,13 @@ ja:
       default: "%Y/%m/%d"
       short:   "%m/%d"
       long:    "%Y年%-m月%-d日(%a)"
+      ymd_hm: "%Y/%m/%d %H:%M"
   time:
     formats:
       default: "%Y/%m/%d %H:%M"
       short:   "%m/%d %H:%M"
       long:    "%Y年%-m月%-d日 %H:%M"
-      ymd_hm: "%Y/%m/%d %H:%M"
+      ymd_hm:  "%Y/%m/%d %H:%M"
   activerecord:
     attributes:
       book_section:
@@ -23,13 +24,34 @@ ja:
       pre_code:
         title: "タイトル"
         body: "コードの説明"
+      book:
+        title: "タイトル"
+        description: "説明"
+        position: "並び順"
     models:
       pre_code: "PreCode"
+      book: "教本"
+    errors:
+      models:
+        book:
+          attributes:
+            position:
+              blank: "を入力してください"
+              not_a_number: "は数値で入力してください"
+              greater_than: "は%{count}より大きい値にしてください"
+              taken: "はすでに使用されています"
   helpers:
     submit:
       book_section:
         create: "作成する"
         update: "更新する"
+      user:
+        update: "更新"
   errors:
     messages:
       blank: "を入力してください"
+  bookmarks:
+    limit_reached: "300件以上のブックマーク登録はできません"
+  search:
+    no_items: "候補はありません"
+    error: "通信エラー"

--- a/db/migrate/20250926052359_add_position_to_books.rb
+++ b/db/migrate/20250926052359_add_position_to_books.rb
@@ -1,0 +1,28 @@
+class AddPositionToBooks < ActiveRecord::Migration[8.0]
+  def up
+    # まず nullable で追加（既存行があるため）
+    add_column :books, :position, :integer
+
+    # created_at 昇順で 1,2,3... を採番（PostgreSQL想定。MySQLならROW_NUMBERの書き方だけ変える）
+    execute <<~SQL.squish
+      WITH ordered AS (
+        SELECT id, ROW_NUMBER() OVER (ORDER BY created_at ASC, id ASC) AS seq
+        FROM books
+      )
+      UPDATE books b SET position = o.seq
+      FROM ordered o
+      WHERE o.id = b.id;
+    SQL
+
+    # 必須化
+    change_column_null :books, :position, false
+
+    # 受入基準の「重複はエラー」を満たすなら unique を付ける（不要なら unique: false に変更可）
+    add_index :books, :position, unique: true
+  end
+
+  def down
+    remove_index :books, :position if index_exists?(:books, :position)
+    remove_column :books, :position
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_03_232404) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_26_052359) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -71,6 +71,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_03_232404) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "book_sections_count", default: 0, null: false
+    t.integer "position", null: false
+    t.index ["position"], name: "index_books_on_position", unique: true
   end
 
   create_table "likes", force: :cascade do |t|

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -1,7 +1,8 @@
 # spec/factories/books.rb
 FactoryBot.define do
   factory :book do
-    sequence(:title)      { |n| "Rails Book #{n}" }
-    description           { "This is a sample book." }
+    sequence(:title)       { |n| "Rails Book #{n}" }
+    description            { "This is a sample book." }
+    sequence(:position)    { |n| n }
   end
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Book, type: :model do
   describe "validations" do
-    it "is valid with title and description" do
+    it "is valid with title, description and position" do
       expect(build(:book)).to be_valid
     end
 
@@ -17,6 +17,23 @@ RSpec.describe Book, type: :model do
       b = build(:book, description: "a" * 501)
       expect(b).to be_invalid
       expect(b.errors[:description]).to be_present
+    end
+
+    it "validates position is integer > 0" do
+      b = build(:book, position: 0)
+      expect(b).to be_invalid
+      expect(b.errors[:position]).to be_present
+
+      b2 = build(:book, position: 1.5)
+      expect(b2).to be_invalid
+      expect(b2.errors[:position]).to be_present
+    end
+
+    it "validates position uniqueness" do
+      create(:book, position: 10)
+      dup = build(:book, position: 10)
+      expect(dup).to be_invalid
+      expect(dup.errors[:position]).to be_present
     end
   end
 

--- a/spec/requests/books_spec.rb
+++ b/spec/requests/books_spec.rb
@@ -5,21 +5,29 @@ RSpec.describe "Books", type: :request do
   include ActionView::Helpers::NumberHelper
 
   describe "GET /books" do
-    it "200 OK & 各教本のタイトル/説明/セクション数(counter_cache) が見える" do
-      book = create(:book, title: "Rails Book", description: "Rails入門")
-      create_list(:book_section, 3, book:)
-      book.reload
+    it "200 OK & 並び順(position昇順)で並ぶ" do
+      # position を逆順で作って、表示は昇順になることを検証
+      b3 = create(:book, title: "Title C", position: 3)
+      b1 = create(:book, title: "Title A", position: 1)
+      b2 = create(:book, title: "Title B", position: 2)
 
       get books_path
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Rails Book")
-      expect(response.body).to include("Rails入門")
-      expect(response.body).to include(number_with_delimiter(book.book_sections_count))
+
+      doc = Nokogiri::HTML.parse(response.body)
+
+      # 本の一覧UL配下の「本詳細へのリンク」テキストを順に拾う
+      # （ビューで <a href="/books/:id">Title ...</a> を想定）
+      titles = doc.css('ul li a[href^="/books/"]').map do |a|
+        a.text.strip.split("\n").first  # 改行前の部分だけ取る
+      end
+
+      expect(titles).to eq([ "Title A", "Title B", "Title C" ])
     end
   end
 
   describe "GET /books/:id" do
-    it "200 OK & 目次(position昇順) が並ぶ" do
+    it "200 OK & 目次(position昇順)が並ぶ" do
       book = create(:book, title: "順序テスト")
       s3 = create(:book_section, book:, heading: "C", position: 3)
       s1 = create(:book_section, book:, heading: "A", position: 1)
@@ -30,19 +38,18 @@ RSpec.describe "Books", type: :request do
 
       doc = Nokogiri::HTML.parse(response.body)
 
-      # 目次の <li> を「番号用の span があるもの」に限定
+      # 画面仕様に合わせたセレクタ（※既存のテストと同じやり方を踏襲）
       toc_lis = doc.css('ul li').select { |li| li.at_css('span.text-slate-400') }
 
-      # 位置 (1., 2., 3.) の並び
-      positions = toc_lis.map { |li| li.at_css('span.text-slate-400').text.strip }
+      # 「1. 2. 3.」の表示順（見出し番号用 span を取得して trim）
+      positions = toc_lis.map { |li| li.at_css('span.text-slate-400')&.text&.strip }
       expect(positions).to eq(%w[1. 2. 3.])
 
-      # 見出し (A, B, C) の並び
-      # 行全体リンク化後は、見出しテキストは span.text-slate-900 に入る
+      # 見出しテキスト（リンク側）
       headings = toc_lis.map { |li| li.at_css('a span.text-slate-900')&.text&.strip }.compact
       expect(headings).to eq(%w[A B C])
 
-      # リンクが存在することの確認
+      # 各セクションへのリンクがあること
       expect(response.body).to include(book_section_path(book, s1))
       expect(response.body).to include(book_section_path(book, s2))
       expect(response.body).to include(book_section_path(book, s3))


### PR DESCRIPTION
### 概要
Rails Books に position を導入して表示順を章番号ベースに統一し、管理画面から編集できるようにした。

**作業内容**

- Migration を追加し books.position を作成、既存データへ created_at 昇順で連番採番し NOT NULL + UNIQUE を付与
- Book モデルに検証（必須・整数>0・一意）と作成時の自動採番を実装、関連は既存どおり book_sections を position で並び替え
- 一般/管理のコントローラを position 昇順での取得に変更し、Strong Params に :position を追加
- 管理フォームに「並び順」入力欄を追加し、未入力/重複時はエラー表示
- Factory/Model/Request Spec を更新し、一覧・詳細の並び順とバリデーションの動作を担保