### PR TITLE
管理画面にPreCode管理を追加（検索/ソート/詳細/編集/削除・50件ページング対応）

### DIFF
--- a/app/controllers/admin/pre_codes_controller.rb
+++ b/app/controllers/admin/pre_codes_controller.rb
@@ -1,0 +1,67 @@
+# app/controllers/admin/pre_codes_controller.rb
+class Admin::PreCodesController < Admin::BaseController
+  layout "admin"
+  before_action :set_pre_code, only: %i[show edit update destroy]
+
+  # GET /admin/pre_codes
+  def index
+    rel = PreCode.includes(:user) # （タグがあれば :tags も）
+    norm = ->(s) { s.to_s.unicode_normalize(:nfkc).downcase }
+
+    if params[:title].present?
+      q = "%#{norm.(params[:title])}%"
+      rel = rel.where("LOWER(pre_codes.title) LIKE ?", q)
+    end
+    if params[:description].present?
+      q = "%#{norm.(params[:description])}%"
+      rel = rel.where("LOWER(pre_codes.description) LIKE ?", q)
+    end
+    if params[:user].present?
+      q = "%#{norm.(params[:user])}%"
+      rel = rel.joins(:user).where("LOWER(users.name) LIKE ? OR LOWER(users.email) LIKE ?", q, q)
+    end
+
+    # タグ AND（Tag/Tagging がある場合）
+    if PreCode.reflect_on_association(:tags) && (tag_ids = Array(params[:tag_ids]).reject(&:blank?)).present?
+      rel = rel.joins(:tags).where(tags: { id: tag_ids })
+               .group("pre_codes.id").having("COUNT(DISTINCT tags.id) = ?", tag_ids.size)
+    end
+
+    rel =
+      case params[:sort]
+      when "likes" then rel.order(like_count: :desc, created_at: :desc)
+      when "used"  then rel.order(use_count:  :desc, created_at: :desc)
+      when "title" then rel.order(Arel.sql("LOWER(pre_codes.title) ASC"))
+      else               rel.order(created_at: :desc)
+      end
+
+    @pre_codes = rel.page(params[:page]).per(50)
+  end
+
+  def show; end
+  def edit; end
+
+  def update
+    if @pre_code.update(pre_code_params)
+      redirect_to [ :admin, @pre_code ], notice: "更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @pre_code.destroy!
+    redirect_to admin_pre_codes_path(request.query_parameters), notice: "削除しました"
+  end
+
+  private
+
+  def set_pre_code
+    @pre_code = PreCode.find(params[:id])
+  end
+
+  # 一般フォームと同じパラメータに合わせる（存在しない項目は削除OK）
+  def pre_code_params
+    params.require(:pre_code).permit(:title, :description, :body, :hint, :answer, :problem_mode, tag_ids: [])
+  end
+end

--- a/app/helpers/admin/pre_codes_helper.rb
+++ b/app/helpers/admin/pre_codes_helper.rb
@@ -1,0 +1,2 @@
+module Admin::PreCodesHelper
+end

--- a/app/views/admin/pre_codes/edit.html.erb
+++ b/app/views/admin/pre_codes/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "PreCode編集" %>
+<h1 class="text-xl font-semibold mb-4">PreCode編集</h1>
+<%= render "pre_codes/form", pre_code: @pre_code %>

--- a/app/views/admin/pre_codes/index.html.erb
+++ b/app/views/admin/pre_codes/index.html.erb
@@ -1,0 +1,105 @@
+<% content_for :title, "PreCode管理" %>
+
+<h1 class="text-xl font-semibold text-slate-900 mb-4">PreCode 管理</h1>
+
+<%= form_with url: admin_pre_codes_path, method: :get, local: true, class: "mb-6" do %>
+  <div class="flex flex-wrap items-end gap-2 md:gap-3">
+
+    <%= text_field_tag :title, params[:title],
+          placeholder: "タイトルを部分一致検索",
+          class: "min-w-[12rem] w-64 md:w-72 rounded-md border ring-1 ring-slate-300 px-3 py-2 text-sm" %>
+
+    <%= text_field_tag :description, params[:description],
+          placeholder: "説明を部分一致検索",
+          class: "min-w-[12rem] w-72 rounded-md border ring-1 ring-slate-300 px-3 py-2 text-sm" %>
+
+    <%= text_field_tag :user, params[:user],
+          placeholder: "ユーザー名／メール",
+          class: "min-w-[12rem] w-64 rounded-md border ring-1 ring-slate-300 px-3 py-2 text-sm" %>
+
+    <%# --- タグ（複数選択） --- %>
+    <% if defined?(Tag) && PreCode.reflect_on_association(:tags) %>
+      <div class="flex items-end gap-2">
+        <label class="text-xs text-slate-500 mb-2">タグ</label>
+        <%= select_tag :tag_ids,
+              options_from_collection_for_select(
+                Tag.order(:name), :id, :name, Array(params[:tag_ids]).map(&:to_i)
+              ),
+              multiple: true, size: 1,
+              class: "min-w-[14rem] md:w-80 rounded-md border ring-1 ring-slate-300 px-2 py-2 text-sm" %>
+      </div>
+    <% end %>
+
+    <div class="flex-1"></div>
+
+    <%= select_tag :sort,
+          options_for_select(
+            [["作成日(新しい順)", ""],
+             ["いいね数", "likes"],
+             ["利用数", "used"],
+             ["タイトル昇順", "title"]],
+            params[:sort]
+          ),
+          class: "rounded-md border ring-1 ring-slate-300 px-3 py-2 text-sm" %>
+
+    <%= submit_tag "検索",
+          class: "rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800" %>
+  </div>
+<% end %>
+
+<div class="overflow-x-auto rounded-lg ring-1 ring-slate-200 bg-white">
+  <table class="min-w-full divide-y divide-slate-200">
+    <thead class="bg-slate-50 text-xs text-slate-600">
+      <tr>
+        <th class="px-3 py-2 text-left"><input type="checkbox" disabled></th>
+        <th class="px-3 py-2 text-left">タイトル</th>
+        <th class="px-3 py-2 text-left">説明(100字)</th>
+        <% if PreCode.reflect_on_association(:tags) %><th class="px-3 py-2 text-left">タグ</th><% end %>
+        <th class="px-3 py-2 text-left">ユーザー</th>
+        <th class="px-3 py-2 text-right">いいね</th>
+        <th class="px-3 py-2 text-right">利用</th>
+        <th class="px-3 py-2 text-left">作成日</th>
+        <th class="px-3 py-2 text-left">操作</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-slate-100 text-sm">
+      <% @pre_codes.each do |p| %>
+        <tr class="hover:bg-slate-50/60">
+          <td class="px-3 py-2"><input type="checkbox" disabled></td>
+          <td class="px-3 py-2 font-medium"><%= p.title %></td>
+          <td class="px-3 py-2 text-slate-600"><%= truncate(p.description.to_s, length: 100) %></td>
+          <% if PreCode.reflect_on_association(:tags) %>
+            <td class="px-3 py-2">
+              <div class="flex flex-wrap gap-1">
+                <% p.tags&.each do |t| %>
+                  <span class="rounded bg-slate-100 px-2 py-0.5 text-[11px] text-slate-700"><%= t.name %></span>
+                <% end %>
+              </div>
+            </td>
+          <% end %>
+          <td class="px-3 py-2"><%= p.user&.name %></td>
+          <td class="px-3 py-2 text-right tabular-nums"><%= p.like_count %></td>
+          <td class="px-3 py-2 text-right tabular-nums"><%= p.use_count %></td>
+          <td class="px-3 py-2"><%= l(p.created_at, format: :short) %></td>
+          <td class="px-3 py-2">
+            <div class="flex flex-wrap gap-2">
+              <%= link_to "詳細", [:admin, p], class: "text-sky-700 hover:underline" %>
+              <%= link_to "編集", [:edit, :admin, p], class: "text-sky-700 hover:underline" %>
+              <%= link_to "削除", [:admin, p],
+                    data: { turbo_method: :delete, turbo_confirm: "この初期データを削除します（復元不可）。よろしいですか？" },
+                    class: "text-rose-700 hover:underline" %>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @pre_codes.blank? %>
+    <div class="p-6 text-center text-sm text-slate-500">該当するデータが見つかりませんでした。</div>
+  <% end %>
+</div>
+
+<div class="mt-6">
+  <%= paginate @pre_codes %>
+</div>

--- a/app/views/admin/pre_codes/show.html.erb
+++ b/app/views/admin/pre_codes/show.html.erb
@@ -1,0 +1,57 @@
+<% content_for :title, "PreCode詳細" %>
+
+<div class="mx-auto w-full max-w-3xl space-y-6">
+
+  <!-- 登録名 -->
+  <section>
+    <h2 class="text-sm font-semibold tracking-wider text-slate-500">登録名</h2>
+    <div class="mt-1 rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3">
+      <p class="text-base text-slate-900"><%= @pre_code.title %></p>
+    </div>
+  </section>
+
+  <!-- コードの説明 -->
+  <section>
+    <h2 class="text-sm font-semibold tracking-wider text-slate-500">コードの説明</h2>
+    <div class="mt-1 rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3">
+      <div class="prose prose-slate max-w-none text-slate-800">
+        <%= simple_format @pre_code.description %>
+      </div>
+    </div>
+  </section>
+
+  <!-- 登録コード + 最終更新 -->
+  <section>
+    <div class="flex items-baseline justify-between">
+      <h2 class="text-sm font-semibold tracking-wider text-slate-500">登録コード</h2>
+      <p class="text-xs text-slate-500">
+        最終更新日：<%= l @pre_code.updated_at.in_time_zone, format: :ymd_hm %>
+      </p>
+    </div>
+
+    <!-- CodeMirror（閲覧専用） -->
+    <style>
+      .cm-editor, .cm-scroller { background: transparent !important; }
+    </style>
+    <div
+      data-controller="code-view"
+      data-code-view-theme-value="light"
+      class="mt-1 rounded-xl ring-1 ring-slate-300 bg-white overflow-hidden"
+    >
+      <textarea data-code-view-target="field" class="hidden"><%= @pre_code.body %></textarea>
+      <div data-code-view-target="mount" class="w-full min-h-[200px]"></div>
+    </div>
+  </section>
+
+  <!-- 操作（右下寄せ） -->
+  <div class="flex justify-end gap-3 pt-2">
+    <%= link_to "編集",
+          edit_pre_code_path(@pre_code),
+          class: "px-5 py-2 rounded-md bg-[#00AA00] text-white hover:bg-[#009900] active:bg-[#008800]" %>
+
+    <%= link_to "削除",
+          @pre_code,
+          data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
+          class: "px-5 py-2 rounded-md bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]" %>
+  </div>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -36,6 +36,7 @@
           <%= link_to "Books",     admin_books_path %>
           <%= link_to "Sections",  admin_book_sections_path %>
           <%= link_to "Users",     admin_users_path %>
+          <%= link_to "PreCode管理",     admin_pre_codes_path %>
 
           <% if current_user&.admin? %>
             <%= button_to "Logout",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
     resource  :session,   only: %i[new create destroy]
     resources :books
     resources :book_sections, except: %i[show]
+    resources :pre_codes, only: %i[index show edit update destroy]
     resources :users, only: [ :index, :destroy ] do
       member do
         patch :toggle_editor

--- a/spec/factories/pre_codes.rb
+++ b/spec/factories/pre_codes.rb
@@ -1,10 +1,18 @@
+# spec/factories/pre_codes.rb
 FactoryBot.define do
   factory :pre_code do
     association :user
-    title       { "Sample Title" }
-    description { "sample description" }
-    body        { "puts 'hello world'" }
-    like_count  { 0 }
-    use_count   { 0 }
+    sequence(:title)       { |n| "Sample Title #{n}" }   # 衝突しにくいように連番化
+    description            { "sample description" }
+    body                   { "puts 'hello world'" }
+    like_count             { 0 }
+    use_count              { 0 }
+  end
+
+  # One-pager のサンプル値に合わせた派生ファクトリ
+  factory :pre_code_sample, parent: :pre_code do
+    title       { "サンプル#{SecureRandom.hex(2)}" }
+    description { "説明テキスト" }
+    body        { "puts 'hello'" }
   end
 end

--- a/spec/requests/admin/pre_codes_spec.rb
+++ b/spec/requests/admin/pre_codes_spec.rb
@@ -1,0 +1,62 @@
+# spec/requests/admin/pre_codes_spec.rb
+require "rails_helper"
+
+RSpec.describe "Admin::PreCodes", type: :request do
+  let(:admin)   { create(:user, admin: true) }
+  let(:user)    { create(:user, name: "太郎", email: "taro@example.com") }
+  let!(:p1)     { create(:pre_code, user:, title: "FizzBuzz", description: "数値の説明", like_count: 3, use_count: 10, created_at: 2.days.ago) }
+  let!(:p2)     { create(:pre_code, user:, title: "Alpha",   description: "alpha desc", like_count: 5, use_count: 5,  created_at: 1.day.ago) }
+
+  before { sign_in admin }
+
+  describe "GET /admin/pre_codes" do
+    it "一覧が表示される" do
+      get admin_pre_codes_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("FizzBuzz", "Alpha")
+    end
+
+    it "タイトルで検索できる（部分一致・小文字化）" do
+      get admin_pre_codes_path, params: { title: "fizz" }
+      expect(response.body).to include("FizzBuzz")
+      expect(response.body).not_to include("Alpha")
+    end
+
+    it "ユーザー名/メールで検索できる" do
+      get admin_pre_codes_path, params: { user: "taro@" }
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("FizzBuzz", "Alpha")
+    end
+
+    it "ソート: like desc" do
+      get admin_pre_codes_path, params: { sort: "likes" }
+      expect(response.body.index("Alpha")).to be < response.body.index("FizzBuzz")
+    end
+  end
+
+  describe "GET /admin/pre_codes/:id" do
+    it { get admin_pre_code_path(p1); expect(response).to have_http_status(:ok) }
+  end
+
+  describe "PATCH /admin/pre_codes/:id" do
+    it "更新できる" do
+      patch admin_pre_code_path(p1), params: { pre_code: { title: "NewTitle" } }
+      expect(response).to redirect_to(admin_pre_code_path(p1))
+      expect(p1.reload.title).to eq("NewTitle")
+    end
+
+    it "失敗時は422" do
+      patch admin_pre_code_path(p1), params: { pre_code: { title: "" } }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "DELETE /admin/pre_codes/:id" do
+    it "削除できる" do
+      expect {
+        delete admin_pre_code_path(p2)
+      }.to change { PreCode.count }.by(-1)
+      expect(response).to redirect_to(admin_pre_codes_path)
+    end
+  end
+end


### PR DESCRIPTION
### 概要
管理画面に PreCode 管理（一覧/詳細/編集/削除）を追加し、検索・ソート・UI を整えた。

**作業内容**

- Admin::PreCodesController を実装し、タイトル/説明/ユーザー/タグ(AND)検索と 4 種ソートを追加
- 一覧・詳細・編集のビューを作成し、テーブル/枠付き表示/CodeMirror 読み取り専用で統一
- 50件/ページのページネーションを実装、削除後は検索条件を保持して一覧へリダイレクト
- 既存フォーム/Stimulus を流用して編集を対応、管理者のみアクセス可に制限
- リクエストスペックと Factory を追加し、基本動作（表示/検索/更新/削除）を検証