### PR TITLE
Remember me（オートログイン）を追加：暗号化クッキーで30日保持・OAuth対応・PW変更/明示ログアウトで失効

### DIFF
--- a/app/controllers/omni_auth_controller.rb
+++ b/app/controllers/omni_auth_controller.rb
@@ -7,12 +7,12 @@ class OmniAuthController < ApplicationController
   end
 
   def callback
-    auth   = request.env["omniauth.auth"] || (raise "omniauth.auth is nil")
-    prov   = auth.provider.to_s          # "google_oauth2" or "github"
-    uid    = auth.uid.to_s
-    info   = auth.info || OpenStruct.new
-    email  = info.email.to_s.downcase.presence
-    name   = info.name.presence || info.nickname.presence || prov.titleize
+    auth  = request.env["omniauth.auth"] || (raise "omniauth.auth is nil")
+    prov  = auth.provider.to_s            # "google_oauth2" / "github"
+    uid   = auth.uid.to_s
+    info  = auth.info || OpenStruct.new
+    email = info.email.to_s.downcase.presence
+    name  = info.name.presence || info.nickname.presence || prov.titleize
 
     # === ① プロフィールからの「接続」か？（link=1 を見て判定） ===
     if current_user && params[:link].present?
@@ -30,22 +30,16 @@ class OmniAuthController < ApplicationController
       redirect_to profile_path, notice: "外部連携を設定しました" and return
     end
 
-    # === ② 通常のログインフロー（既存実装） ===
-    authentication = Authentication.find_by(provider: prov, uid: uid)
-    if authentication
-      user = authentication.user
-      reset_session
-      session[:user_id] = user.id
-      user.update_column(:last_login_at, Time.current)
-      redirect_to root_path, notice: "#{provider_label(prov)}でログインしました" and return
+    # === ② 通常のログインフロー（成功時は Remember を適用） ===
+    if (authentication = Authentication.find_by(provider: prov, uid: uid))
+      return user_login!(authentication.user,
+                         notice: "#{provider_label(prov)}でログインしました")
     end
 
     if email && (user = User.where("lower(email) = ?", email).first)
       user.authentications.find_or_create_by!(provider: prov, uid: uid)
-      reset_session
-      session[:user_id] = user.id
-      user.update_column(:last_login_at, Time.current)
-      redirect_to root_path, notice: "#{provider_label(prov)}をあなたのアカウントに連携しました" and return
+      return user_login!(user,
+                         notice: "#{provider_label(prov)}をあなたのアカウントに連携しました")
     end
 
     # 新規ユーザー作成（ダミーパスワード）
@@ -55,10 +49,7 @@ class OmniAuthController < ApplicationController
       password: SecureRandom.urlsafe_base64(24)
     )
     user.authentications.create!(provider: prov, uid: uid)
-    reset_session
-    session[:user_id] = user.id
-    user.update_column(:last_login_at, Time.current)
-    redirect_to root_path, notice: "#{provider_label(prov)}で新規登録しました"
+    user_login!(user, notice: "#{provider_label(prov)}で新規登録しました")
 
   rescue => e
     Rails.logger.error("[OmniAuth #{e.class}] #{e.message}\n#{e.backtrace&.first}")
@@ -70,6 +61,35 @@ class OmniAuthController < ApplicationController
   end
 
   private
+
+  # 成功時の共通処理（セッション確立 + last_login_at 更新 + Remember 適用 + リダイレクト）
+  def user_login!(user, notice:)
+    reset_session
+    session[:user_id] = user.id
+    user.update_column(:last_login_at, Time.current)
+    remember_if_needed!(user) # ★ 追加：Remember対応
+    redirect_to root_path, notice:
+  end
+
+  # 「ログイン状態を保持する」選択時に Remember クッキーを発行
+  # - params[:remember] == "1" … パスワード/外部ログイン共通の即時指定
+  # - cookies.encrypted[:remember_intent] == "1" … /auth/:provider に遷移する前に仕込んでおくワンショット意図
+  def remember_if_needed!(user)
+    return unless params[:remember] == "1" || cookies.encrypted[:remember_intent] == "1"
+
+    token = user.remember! # user側で digest 保存 & トークン発行する想定
+
+    cookies.encrypted[:remember_me] = {
+      value:    { user_id: user.id, token: token },
+      expires:  30.days,
+      httponly: true,
+      secure:   Rails.env.production?,
+      same_site: :lax
+    }
+
+    # ワンショットの意図フラグは使い切り
+    cookies.delete(:remember_intent, same_site: :lax, secure: Rails.env.production?)
+  end
 
   def provider_label(provider)
     case provider

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -28,6 +28,8 @@ class ProfilesController < ApplicationController
         return render :edit, status: :unprocessable_entity
       end
       if @user.update(password_params)
+        @user.revoke_all_remember!
+        cookies.delete(:remember_me, same_site: :lax, secure: Rails.env.production?)
         redirect_to profile_path, notice: "パスワードを更新しました"
       else
         render :edit, status: :unprocessable_entity
@@ -35,6 +37,11 @@ class ProfilesController < ApplicationController
     else
       head :bad_request
     end
+  end
+
+  def revoke_remember
+    current_user.revoke_all_remember!
+    redirect_to profile_path, notice: "他の端末のログイン状態をすべて解除しました"
   end
 
   private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,18 +9,17 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:email])
 
-    # ユーザーが存在する場合のみBANチェック
     if user&.banned?
       flash.now[:alert] = "このアカウントは凍結されています"
-      render :new, status: :forbidden
-      return
+      return render :new, status: :forbidden
     end
 
-    # 通常ログイン：外部連携アカウント(authenticationsあり)はパスワード不要
     if user&.uses_password? && user&.authenticate(params[:password])
       reset_session
       session[:user_id] = user.id
       user.update_column(:last_login_at, Time.current)
+      remember_if_needed!(user)
+
       redirect_to root_path, notice: "ログインしました"
     else
       flash.now[:alert] = "メールまたはパスワードが正しくありません"
@@ -29,6 +28,8 @@ class SessionsController < ApplicationController
   end
 
   def destroy
+    current_user&.forget!
+    cookies.delete(:remember_me, same_site: :lax, secure: Rails.env.production?)
     reset_session
     redirect_to root_path, notice: "ログアウトしました"
   end
@@ -37,5 +38,18 @@ class SessionsController < ApplicationController
 
   def use_gray_bg
     @body_bg = "bg-slate-50"
+  end
+
+  def remember_if_needed!(user)
+    return unless params[:remember_me] == "1"
+
+    token = user.remember!
+    cookies.encrypted[:remember_me] = {
+      value:   { user_id: user.id, token: token },
+      expires: 30.days,
+      httponly: true,
+      secure: Rails.env.production?,
+      same_site: :lax
+    }
   end
 end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -55,4 +55,16 @@
       <%= render "profiles/oauth_link_buttons" %>
     </div>
   </section>
+
+  <!-- セクション4：他端末ログアウト -->
+  <section>
+    <h2 class="text-sm font-semibold tracking-wider text-slate-500">セキュリティ</h2>
+    <div class="mt-2 rounded-xl bg-white ring-1 ring-slate-200 p-4">
+      <%= button_to "他の端末のログイン状態を解除",
+            revoke_remember_profile_path,
+            method: :post,
+            form: { data: { turbo_confirm: "現在利用している端末以外のすべての端末のログイン状態を解除します。よろしいですか？" } },
+            class: "rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-500" %>
+    </div>
+  </section>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -20,6 +20,11 @@
                class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" />
       </div>
 
+      <div class="mt-2 flex items-center gap-2">
+        <%= check_box_tag :remember_me, "1", false, id: "remember_me" %>
+        <%= label_tag :remember_me, "ログイン状態を保持する", class: "text-sm text-slate-600" %>
+      </div>
+
       <%# ログインボタン：赤 %>
       <%= f.submit "ログイン",
             class: "w-full bg-[#CC0000] text-white py-2 rounded-xl hover:bg-[#BB0000] active:bg-[#AA0000]" %>

--- a/app/views/shared/_oauth_buttons.html.erb
+++ b/app/views/shared/_oauth_buttons.html.erb
@@ -1,10 +1,10 @@
 <div class="space-y-2">
-  <%= link_to "/auth/google_oauth2",
+  <%= link_to "/auth/google_oauth2?remember=1",
       class: "inline-flex w-full items-center justify-center gap-2 rounded-xl bg-white ring-1 ring-slate-200 px-4 py-2 hover:bg-slate-50" do %>
     <span class="font-medium text-slate-700">Google でログイン</span>
   <% end %>
 
-  <%= link_to "/auth/github",
+  <%= link_to "/auth/github?remember=1",
       class: "inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800" do %>
     <span class="font-medium">GitHub でログイン</span>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,4 @@
 Rails.application.routes.draw do
-  get "profiles/show"
-  get "profiles/edit"
-  get "profiles/update"
   # 静的ページ
   get "help",    to: "static_pages#help"
   get "terms",   to: "static_pages#terms"
@@ -18,7 +15,9 @@ Rails.application.routes.draw do
   resources :password_resets, only: %i[new create edit update]  # パス再設定用
 
   # ユーザープロフィール
-  resource :profile, only: %i[show edit update]
+  resource :profile, only: %i[show edit update] do
+    post :revoke_remember   # /profile/revoke_remember
+  end
 
   # PreCode機能
   concern :paginatable do

--- a/db/migrate/20250926083054_add_remember_to_users.rb
+++ b/db/migrate/20250926083054_add_remember_to_users.rb
@@ -1,0 +1,6 @@
+class AddRememberToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :remember_digest, :string
+    add_column :users, :remember_created_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_26_075500) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_26_083054) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -135,6 +135,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_26_075500) do
     t.datetime "banned_at"
     t.string "ban_reason"
     t.datetime "last_login_at"
+    t.string "remember_digest"
+    t.datetime "remember_created_at"
     t.index "lower((email)::text)", name: "index_users_on_lower_email_unique", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token_unique", unique: true
   end

--- a/spec/requests/omni_auth_spec.rb
+++ b/spec/requests/omni_auth_spec.rb
@@ -83,6 +83,17 @@ RSpec.describe "OmniAuth", type: :request do
         }.not_to change(User, :count)
       end
     end
+
+    # ===== Remember 発行の確認（追加） =====
+    it "provider ログイン成功時に remember=1 でRememberクッキーが発行される" do
+      user = create(:user, email: "foo@example.com")
+      mock_omniauth(provider: "github", uid: "u1", email: "foo@example.com")
+
+      get omni_auth_callback_path(provider: "github", remember: "1")
+
+      expect(response).to redirect_to(root_path)
+      expect(cookies['remember_me']).to be_present
+    end
   end
 
   describe "GET /auth/failure" do

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -43,5 +43,28 @@ RSpec.describe "Profiles", type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body).to include("現在のパスワードが違います")
     end
+
+    # ===== Remember 強制失効の確認（追加） =====
+    it "パスワード更新時に全端末のRememberが失効する" do
+      user.remember! # digestが入る
+      expect(user.remember_digest).to be_present
+
+      patch profile_path, params: {
+        user: { current_password: "secret123", password: "newpass1", password_confirmation: "newpass1" },
+        commit: "パスワード更新"
+      }
+      expect(response).to redirect_to(profile_path)
+      expect(user.reload.remember_digest).to be_blank
+    end
+  end
+
+  # ===== 「他の端末からもログアウト」ボタンの確認（追加） =====
+  describe "POST /profile/revoke_remember" do
+    it "全端末のRememberが失効する" do
+      user.remember!
+      post revoke_remember_profile_path
+      expect(response).to redirect_to(profile_path)
+      expect(user.reload.remember_digest).to be_blank
+    end
   end
 end


### PR DESCRIPTION
### 概要
「ログイン状態を保持する（Remember me）」を追加し、30日間の自動ログイン・OAuth対応・安全な失効処理を実装した。

**作業内容**

- users に remember_digest / remember_created_at を追加し、BCrypt でのトークン発行/検証APIを User に実装
- ApplicationController の current_user に Remember 復帰を組み込み、暗号化クッキーから自動ログイン＆last_login_at 更新を実現
- Sessions/OmniAuth の成功時に remember=1 でクッキー発行、明示ログアウト時はサーバ/クッキー双方を確実に失効
- プロフィールに「他の端末からもログアウト」ボタンを追加し、パスワード変更時も全端末の Remember を強制失効
- ログイン画面へチェックボックスと OAuth ボタンの remember=1 を追加、リクエストスペックで発行/復帰/削除を検証