### PR TITLE
PreCodeタグ機能を追加：Tag/Taggingモデル・AND検索・フォーム入力・管理の統合/削除を実装

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -1,0 +1,34 @@
+# app/controllers/admin/tags_controller.rb
+class Admin::TagsController < Admin::BaseController
+  layout "admin"
+
+  def index
+    @q = params[:q].to_s
+    @tags = Tag.used.prefix(@q).order_for_suggest.page(params[:page])
+  end
+
+  def merge
+    from = Tag.find(params[:from_id]); to = Tag.find(params[:to_id])
+    raise ActiveRecord::RecordInvalid, "同一タグへは統合できません" if from.id == to.id
+
+    Tag.transaction do
+      PreCodeTagging.where(tag_id: from.id).update_all(tag_id: to.id)
+      # 重複排除
+      PreCodeTagging.group(:pre_code_id, :tag_id).having("COUNT(*) > 1").pluck(:pre_code_id, :tag_id).each do |pid, tid|
+        PreCodeTagging.where(pre_code_id: pid, tag_id: tid).offset(1).delete_all
+      end
+      # カウンタ再計算（簡易）
+      Tag.reset_counters(to.id, :pre_code_taggings)
+      Tag.reset_counters(from.id, :pre_code_taggings)
+      from.destroy! if from.taggings_count.zero?
+    end
+    redirect_to admin_tags_path, notice: "統合しました"
+  end
+
+  def destroy
+    tag = Tag.find(params[:id])
+    return redirect_to admin_tags_path, alert: "使用中のタグは削除できません" unless tag.taggings_count.zero?
+    tag.destroy!
+    redirect_to admin_tags_path, notice: "削除しました"
+  end
+end

--- a/app/controllers/pre_codes_controller.rb
+++ b/app/controllers/pre_codes_controller.rb
@@ -5,13 +5,33 @@ class PreCodesController < ApplicationController
   # GET /pre_codes
   def index
     base = current_user.pre_codes
+
+    # --- タグ AND フィルタ ---
+    if params[:tags].present?
+      tag_keys = parse_tags(params[:tags]) # "ruby,array" or ["ruby","array"]
+      norm_keys = tag_keys.map { |n| normalize_tag(n) }.uniq
+
+      if norm_keys.any?
+        tag_ids = Tag.where(name_norm: norm_keys).pluck(:id)
+        base =
+          if tag_ids.any?
+            # AND 検索：選んだタグ数と一致するまで group/having
+            base.joins(:tags)
+                .where(tags: { id: tag_ids })
+                .group("pre_codes.id")
+                .having("COUNT(DISTINCT tags.id) = ?", tag_ids.size)
+          else
+            base.none
+          end
+      end
+    end
+
     @q = base.ransack(params[:q])
     @pre_codes = @q.result.order(id: :desc).page(params[:page])
   end
 
   # GET /pre_codes/:id
-  def show
-  end
+  def show; end
 
   # GET /pre_codes/new
   def new
@@ -22,6 +42,8 @@ class PreCodesController < ApplicationController
   def create
     @pre_code = current_user.pre_codes.build(pre_code_params)
     if @pre_code.save
+      # タグ適用（保存後に差分反映）
+      TaggingService.new(@pre_code, current_user: current_user).apply!(params[:tag_names])
       redirect_to @pre_code, notice: "PreCode を作成しました"
     else
       render :new, status: :unprocessable_entity
@@ -29,12 +51,13 @@ class PreCodesController < ApplicationController
   end
 
   # GET /pre_codes/:id/edit
-  def edit
-  end
+  def edit; end
 
   # PATCH/PUT /pre_codes/:id
   def update
     if @pre_code.update(pre_code_params)
+      # タグ適用（保存後に差分反映）
+      TaggingService.new(@pre_code, current_user: current_user).apply!(params[:tag_names])
       redirect_to @pre_code, notice: "PreCode を更新しました"
     else
       render :edit, status: :unprocessable_entity
@@ -49,7 +72,7 @@ class PreCodesController < ApplicationController
 
   private
 
-  # 所有者スコープで取得（他人のIDだと ActiveRecord::RecordNotFound → 404）
+  # 所有者スコープで取得（他人IDは 404）
   def set_pre_code
     @pre_code = current_user.pre_codes.find(params[:id])
   end
@@ -57,5 +80,19 @@ class PreCodesController < ApplicationController
   # Strong Parameters
   def pre_code_params
     params.require(:pre_code).permit(:title, :description, :body)
+  end
+
+  # "ruby,array" / ["ruby","array"] を配列に整形
+  def parse_tags(val)
+    Array(val).flat_map { |v| v.to_s.split(",") }.map(&:strip).reject(&:blank?)
+  end
+
+  # Tag.normalize があれば使用。無ければ簡易正規化（NFKC→strip→downcase→空白正規化）
+  def normalize_tag(name)
+    if Tag.respond_to?(:normalize)
+      Tag.normalize(name)
+    else
+      name.to_s.unicode_normalize(:nfkc).strip.downcase.gsub(/\s+/, " ")
+    end
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,16 @@
+# app/controllers/tags_controller.rb
+class TagsController < ApplicationController
+  def index
+    # 候補API: /tags.json?query=ru
+    @tags = Tag.used.prefix(params[:query]).order_for_suggest.limit(20)
+    respond_to do |f|
+      f.html { redirect_to root_path } # 画面不要
+      f.json { render json: @tags.as_json(only: [ :id, :name, :slug, :color ]) }
+    end
+  end
+
+  def show
+    @tag = Tag.find_by!(slug: params[:id])
+    redirect_to pre_codes_path(tags: @tag.name) # 既存一覧を流用
+  end
+end

--- a/app/helpers/admin/tags_helper.rb
+++ b/app/helpers/admin/tags_helper.rb
@@ -1,0 +1,2 @@
+module Admin::TagsHelper
+end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,0 +1,13 @@
+module TagsHelper
+  # "#RRGGBB" → "rgba(r,g,b,alpha)"
+  def tag_rgba_bg(hex, alpha = 0.12)
+    return "rgba(107,114,128,0.12)" if hex.blank? # slate-500 fallback
+    hex = hex.delete("#")
+    r = hex[0..1].to_i(16)
+    g = hex[2..3].to_i(16)
+    b = hex[4..5].to_i(16)
+    "rgba(#{r},#{g},#{b},#{alpha})"
+  rescue
+    "rgba(107,114,128,0.12)"
+  end
+end

--- a/app/javascript/controllers/tag_token_controller.js
+++ b/app/javascript/controllers/tag_token_controller.js
@@ -1,0 +1,14 @@
+// app/javascript/controllers/tag_token_controller.js
+import { Controller } from "@hotwired/stimulus"
+export default class extends Controller {
+  suggest(e) {
+    const q = e.target.value.split(",").pop().trim()
+    if (!q) return
+    fetch(`/tags.json?query=${encodeURIComponent(q)}`)
+      .then(r => r.json())
+      .then(list => {
+        const names = list.slice(0, 6).map(t => t.name).join(", ")
+        document.getElementById("tag-suggest").textContent = names ? `候補: ${names}` : ""
+      })
+  }
+}

--- a/app/models/pre_code.rb
+++ b/app/models/pre_code.rb
@@ -1,7 +1,10 @@
+# app/models/pre_code.rb
 class PreCode < ApplicationRecord
   belongs_to :user
   has_many :likes,      dependent: :destroy
   has_many :used_codes, dependent: :destroy
+  has_many :pre_code_taggings, dependent: :destroy
+  has_many :tags, through: :pre_code_taggings
 
   validates :title,
             presence: true,
@@ -11,10 +14,17 @@ class PreCode < ApplicationRecord
   validates :description, length: { maximum: 2000 }, allow_blank: true
   validates :body, presence: true
 
-  # === 一覧向けスコープ ===
-  scope :except_user, ->(user_id) { user_id.present? ? where.not(user_id: user_id) : all }
-  scope :popular,     -> { order(like_count: :desc, id: :desc) }
-  scope :most_used,   -> { order(use_count: :desc,   id: :desc) }
+  # === 一覧・並び替え向けスコープ ===
+  scope :except_user, ->(uid) { uid.present? ? where.not(user_id: uid) : all }
+  scope :popular,     ->       { order(like_count: :desc, id: :desc) }
+  scope :most_used,   ->       { order(use_count: :desc,  id: :desc) }
+  scope :tagged_with_all, ->(tag_ids) {
+    next all if tag_ids.blank?
+    joins(:tags)
+      .where(tags: { id: tag_ids })
+      .group("pre_codes.id")
+      .having("COUNT(DISTINCT tags.id) = ?", Array(tag_ids).size)
+  }
 
   # === Ransack 4 (Rails 7+) 許可リスト ===
   def self.ransackable_attributes(_auth = nil)

--- a/app/models/pre_code_tagging.rb
+++ b/app/models/pre_code_tagging.rb
@@ -1,0 +1,7 @@
+# app/models/pre_code_tagging.rb
+class PreCodeTagging < ApplicationRecord
+  belongs_to :pre_code
+  belongs_to :tag, counter_cache: :taggings_count
+
+  validates :pre_code_id, uniqueness: { scope: :tag_id }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,47 @@
+# app/models/tag.rb
+class Tag < ApplicationRecord
+  has_many :pre_code_taggings, dependent: :destroy
+  has_many :pre_codes, through: :pre_code_taggings
+
+  before_validation :set_normalized_fields
+  validates :name, presence: true, length: { in: 1..30 }
+  validates :name_norm, presence: true, uniqueness: true
+  validates :color, format: { with: /\A#[0-9A-Fa-f]{6}\z/ }, allow_blank: true
+
+  scope :used,   -> { where("taggings_count > 0") }
+  scope :prefix, ->(q) { where("name_norm LIKE ?", "#{normalize(q)}%") if q.present? }
+  scope :order_for_suggest, -> { order(taggings_count: :desc, name_norm: :asc) }
+
+  # === class utilities ===
+  def self.normalize(s) = ActiveSupport::Inflector.transliterate(s.to_s.unicode_normalize(:nfkc).strip.downcase.gsub(/\s+/, " "))
+  def self.slugify(s)
+    base = normalize(s).gsub(/[^a-z0-9\- ]/, "").tr(" ", "-").gsub(/\-+/, "-")
+    base.presence || "tag"
+  end
+
+  private
+
+  def set_normalized_fields
+    self.name      = name.to_s.strip if name
+    self.name_norm = Tag.normalize(name) if name
+    self.slug    ||= begin
+      base = Tag.slugify(name)
+      candidate = base
+      i = 2
+      while Tag.exists?(slug: candidate) && Tag.find_by(slug: candidate) != self
+        candidate = "#{base}-#{i}"; i += 1
+      end
+      candidate
+    end
+    self.color   ||= auto_color(name_norm)
+  end
+
+  # name_norm から安定色を作る（HSL→RGBの簡易版）
+  def auto_color(key)
+    h = Zlib.crc32(key.to_s) % 360
+    s = 55; l = 65
+    Color::HSL.new(h, s, l).to_rgb.html   # color-rgb gem等を使わない場合は自前で変換
+  rescue
+    "#6B7280" # fallback: slate-500
+  end
+end

--- a/app/services/tagging_service.rb
+++ b/app/services/tagging_service.rb
@@ -1,0 +1,33 @@
+# app/services/tagging_service.rb
+class TaggingService
+  MAX_PER_PRE_CODE = 10
+  MAX_TAGS_GLOBAL  = (ENV.fetch("MAX_TAGS", "50000").to_i rescue 50000)
+
+  def initialize(pre_code, current_user:)
+    @pre_code = pre_code
+    @current_user = current_user
+  end
+
+  # tag_input: ["Ruby", "array"] or "ruby,array"
+  def apply!(tag_input)
+    names = Array(tag_input.is_a?(String) ? tag_input.split(",") : tag_input).map(&:to_s).map(&:strip).reject(&:blank?)
+    names = names.first(MAX_PER_PRE_CODE)
+
+    tags = names.map { |raw| find_or_create_tag!(raw) }.compact
+    @pre_code.tags = tags.uniq
+  end
+
+  private
+
+  def find_or_create_tag!(raw)
+    norm = Tag.normalize(raw)
+    Tag.find_by(name_norm: norm) || create_tag!(raw, norm)
+  end
+
+  def create_tag!(raw, norm)
+    raise ActiveRecord::RecordInvalid, "上限到達" if Tag.count >= MAX_TAGS_GLOBAL
+    Tag.create!(name: raw) # before_validation が name_norm/slug/color を決める
+  rescue ActiveRecord::RecordNotUnique
+    Tag.find_by!(name_norm: norm) # 競合時は既存を返す
+  end
+end

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -1,0 +1,84 @@
+<%# app/views/admin/tags/index.html.erb %>
+
+<h1 class="text-xl font-bold mb-4">Tags</h1>
+
+<%= form_with url: admin_tags_path, method: :get, local: true, class: "mb-4 flex gap-2" do %>
+  <input type="text"
+         name="q"
+         value="<%= params[:q].to_s %>"
+         placeholder="名前で検索"
+         class="flex-1 rounded-xl ring-1 ring-slate-300 px-3 py-2" />
+  <button class="rounded-xl px-4 py-2 ring-1 ring-slate-300">検索</button>
+<% end %>
+
+<div class="rounded-xl ring-1 ring-slate-200 overflow-hidden">
+  <table class="w-full text-sm">
+    <thead class="bg-slate-50">
+      <tr>
+        <th class="p-2 text-right w-16">ID</th>
+        <th class="p-2 text-left">Name</th>
+        <th class="p-2 text-left">Slug</th>
+        <th class="p-2 text-left">Color</th>
+        <th class="p-2 text-right">Used</th>
+        <th class="p-2">Actions</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @tags.each do |t| %>
+        <tr class="border-t">
+          <td class="p-2 text-right font-mono"><%= t.id %></td>
+          <td class="p-2"><%= t.name %></td>
+          <td class="p-2"><%= t.slug %></td>
+          <td class="p-2">
+            <%# 色スウォッチ + HEX 表示（背景色は直接指定） %>
+            <span class="inline-block w-4 h-4 rounded align-middle"
+                  style="background-color: '<%= t.color.presence || '#6B7280' %>'"></span>
+            <code class="ml-1 text-xs align-middle"><%= t.color %></code>
+          </td>
+          <td class="p-2 text-right"><%= t.taggings_count %></td>
+          <td class="p-2">
+            <% if t.taggings_count.zero? %>
+              <%= link_to "削除",
+                          admin_tag_path(t),
+                          data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
+                          class: "text-red-600 underline" %>
+            <% else %>
+              <span class="text-slate-400">削除不可</span>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<%# === 統合フォーム === %>
+<div class="mt-6 p-4 rounded-xl ring-1 ring-slate-200">
+  <h2 class="font-semibold mb-2">統合</h2>
+
+  <%= form_with url: merge_admin_tags_path, method: :post, local: true, class: "flex flex-wrap gap-3 items-end" do %>
+    <div class="flex-1 min-w-[16rem]">
+      <label class="text-xs text-slate-500">From（統合元ID）</label>
+      <input type="number" name="from_id" class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2" required />
+    </div>
+
+    <div class="flex-1 min-w-[16rem]">
+      <label class="text-xs text-slate-500">To（統合先ID）</label>
+      <input type="number" name="to_id" class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2" required />
+    </div>
+
+    <button class="rounded-xl px-4 py-2 ring-1 ring-slate-300">統合</button>
+
+    <div class="basis-full text-xs text-slate-500 mt-1">
+      ※ 統合を実行すると、
+      <span class="font-semibold">From（統合元）タグ</span> に紐づく PreCode との関連は、
+      <span class="font-semibold">To（統合先）タグ</span> に移管され、重複は自動で除去されます。<br>
+      ※ 統合後に統合元のタグが未使用になった場合は自動で削除されます。
+    </div>
+  <% end %>
+</div>
+
+<div class="mt-4">
+  <%= paginate @tags if respond_to?(:paginate) %>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -41,10 +41,18 @@
 
           <!-- 編集者バッジ -->
           <td class="px-4 py-2">
-            <% if u.editor? %>
-              <span class="inline-flex items-center rounded-full bg-indigo-50 px-2.5 py-0.5 text-xs font-medium text-indigo-700 ring-1 ring-inset ring-indigo-200">編集者</span>
+            <% if u.admin? %>
+              <span class="inline-flex items-center rounded-full bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-200">
+                管理者
+              </span>
+            <% elsif u.editor? %>
+              <span class="inline-flex items-center rounded-full bg-indigo-50 px-2.5 py-0.5 text-xs font-medium text-indigo-700 ring-1 ring-inset ring-indigo-200">
+                編集者
+              </span>
             <% else %>
-              <span class="inline-flex items-center rounded-full bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-600 ring-1 ring-inset ring-slate-200">一般</span>
+              <span class="inline-flex items-center rounded-full bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-600 ring-1 ring-inset ring-slate-200">
+                一般
+              </span>
             <% end %>
           </td>
 

--- a/app/views/code_libraries/index.html.erb
+++ b/app/views/code_libraries/index.html.erb
@@ -2,23 +2,21 @@
 <% breadcrumb :code_libraries %>
 <%= render "shared/breadcrumbs" %>
 
-<%# ページ <title> 用（SEO等） %>
+<%# ページ <title> 用 %>
 <% content_for :title, "Code Library" %>
 
-<%# ===== ヘッダーブロック：中央にタイトル、その“下の行”に右寄せの検索群 ===== %>
+<%# ===== ヘッダーブロック ===== %>
 <div class="mb-6">
-
-  <%# 中央タイトル %>
   <div class="text-center">
     <h1 class="text-2xl font-semibold">Code Library</h1>
     <p class="mt-1 text-sm text-slate-500">~ 初期データ閲覧機能 ~</p>
   </div>
 
-  <%# タイトルの下の行：右寄せで検索フォーム＆使い方 %>
   <div class="mt-4">
     <div class="flex gap-2 justify-end">
       <%= search_form_for @q, url: code_libraries_path, method: :get,
             html: { class: "flex gap-2" } do |f| %>
+
         <%= f.search_field :title_or_description_cont,
               value: @q.title_or_description_cont,
               placeholder: "検索（タイトル／説明）",
@@ -36,6 +34,11 @@
       <% end %>
     </div>
 
+    <%# ← ここが追加：Code Library 向けのタグ検索（送り先を指定） %>
+    <div class="flex mt-2 justify-end">
+      <%= render "shared/tag_filter", url: code_libraries_path %>
+    </div>
+
     <div class="flex mt-2 justify-end">
       <%= link_to "使い方", help_path,
             class: "px-3 py-2 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]" %>
@@ -43,7 +46,7 @@
   </div>
 </div>
 
-<%# --- 一覧 --- %>
+<%# ===== 一覧 ===== %>
 <% if @pre_codes.blank? %>
   <p class="text-slate-500">該当するデータがありません。</p>
 <% else %>
@@ -56,18 +59,24 @@
               "aria-label": "#{pc.title} の詳細" do %>
         <% end %>
 
-        <%# 上段：タイトル/説明 + 右上メトリクス %>
         <div class="flex justify-between">
           <div class="flex-1 pr-4">
             <div class="font-semibold"><%= pc.title %></div>
-            <p class="text-sm text-slate-500 mt-1"><%= truncate(pc.description, length: 100) %></p>
+
+            <%# タイトルの下に「静的」タグピルを表示（リンクなし・ネスト事故回避） %>
+            <div class="mt-2">
+              <%= render "shared/tag_pills_static", record: pc %>
+            </div>
+
+            <p class="text-sm text-slate-500 mt-2"><%= truncate(pc.description, length: 100) %></p>
           </div>
+
           <div class="shrink-0">
             <%= render "metrics", pre_code: pc %>
           </div>
         </div>
 
-        <%# 下段：アクション（※ここが肝） - 上の透明リンクを拾わない %>
+        <%# 下段：アクション（透明リンクを拾わないように） %>
         <div class="mt-3 flex items-center gap-2 pointer-events-none">
           <div class="pointer-events-auto z-20">
             <%= render "actions",
@@ -79,7 +88,6 @@
     <% end %>
   </ul>
 
-  <%# ページネーション（検索条件を保持して遷移） %>
   <div class="mt-6">
     <%= paginate @pre_codes, params: request.query_parameters %>
   </div>

--- a/app/views/code_libraries/show.html.erb
+++ b/app/views/code_libraries/show.html.erb
@@ -1,4 +1,4 @@
-<!-- app/views/code_libraries/show.html.erb -->
+<%# app/views/code_libraries/show.html.erb %>
 <% breadcrumb :code_libraries %>
 <% breadcrumb :code_library, @pre_code %>
 <%= render "shared/breadcrumbs" %>
@@ -11,6 +11,14 @@
     <h2 class="text-sm font-semibold tracking-wider text-slate-500">登録名</h2>
     <div class="mt-1 rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3">
       <p class="text-base"><%= @pre_code.title %></p>
+    </div>
+  </section>
+
+  <!-- タグ -->
+  <section>
+    <h2 class="text-sm font-semibold tracking-wider text-slate-500">タグ</h2>
+    <div class="mt-1">
+      <%= render "shared/tag_pills_static", record: @pre_code %>
     </div>
   </section>
 
@@ -31,23 +39,17 @@
       </p>
     </div>
 
-    <!-- CodeMirror（閲覧専用） -->
-    <style>
-      .cm-editor, .cm-scroller { background: transparent !important; }
-    </style>
-    <div
-      data-controller="code-view"
-      data-code-view-theme-value="light"
-      class="mt-1 rounded-xl ring-1 ring-slate-300 overflow-hidden">
+    <style>.cm-editor,.cm-scroller{background:transparent!important}</style>
+    <div data-controller="code-view" data-code-view-theme-value="light"
+         class="mt-1 rounded-xl ring-1 ring-slate-300 overflow-hidden">
       <textarea data-code-view-target="field" class="hidden"><%= @pre_code.body %></textarea>
       <div data-code-view-target="mount" class="w-full min-h-[120px]"></div>
     </div>
   </section>
 
-  <!-- 利用ボタン ＋ いいねボタン（同一行・中央固定） -->
+  <!-- 利用ボタン ＋ いいねボタン -->
   <section class="-mt-2">
     <div class="grid grid-cols-3 items-center">
-      <!-- 中央：利用ボタン（PreCode送信ボタンと同じサイズ） -->
       <div class="col-start-2 justify-self-center">
         <%= button_to "このデータを利用する",
               used_codes_path(pre_code_id: @pre_code.id,
@@ -59,7 +61,6 @@
                       hover:bg-[#BB0000] active:bg-[#AA0000]" %>
       </div>
 
-      <!-- 右端：いいねボタン -->
       <div class="col-start-3 justify-self-end">
         <% current_like = logged_in? ? @pre_code.likes.find_by(user_id: current_user.id) : nil %>
         <%= render "actions", pre_code: @pre_code, current_like: current_like %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -37,6 +37,7 @@
           <%= link_to "Sections",  admin_book_sections_path %>
           <%= link_to "Users",     admin_users_path %>
           <%= link_to "PreCode管理",     admin_pre_codes_path %>
+          <%= link_to "Tags",       admin_tags_path %>
 
           <% if current_user&.admin? %>
             <%= button_to "Logout",

--- a/app/views/pre_codes/_form.html.erb
+++ b/app/views/pre_codes/_form.html.erb
@@ -11,6 +11,15 @@
           class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
   </div>
 
+  <%# === タグ === %>
+  <div class="mt-4">
+    <label class="block text-sm mb-1">タグ（最大10個）</label>
+    <input id="tag-input" name="tag_names" value="<%= @pre_code.tags.map(&:name).join(',') %>"
+          class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2"
+          placeholder="例: ruby, array, sql" data-controller="tag-token" data-action="input->tag-token#suggest">
+    <div id="tag-suggest" class="mt-1 text-sm text-slate-500"></div>
+  </div>
+
   <div>
     <%# コードの説明 %>
     <%= f.label :description, "コードの説明", class: "block text-sm mb-1" %>

--- a/app/views/pre_codes/index.html.erb
+++ b/app/views/pre_codes/index.html.erb
@@ -25,6 +25,10 @@
       <% end %>
     </div>
 
+    <div class="flex mt-2 justify-end">
+      <%= render "shared/tag_filter" %>
+    </div>
+
     <div class="flex gap-2 mt-2 justify-end">
       <%= link_to "使い方", help_path,
             class: "px-3 py-2 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]" %>
@@ -45,8 +49,16 @@
           <div class="flex justify-between">
             <!-- 左：タイトル／説明 -->
             <div class="flex-1 pr-4">
+              <!-- タイトル -->
               <div class="font-semibold"><%= pc.title %></div>
-              <p class="text-sm text-slate-500 mt-1"><%= truncate(pc.description, length: 120) %></p>
+
+              <!-- タグピル（タイトルの下） -->
+              <div class="mt-2">
+                <%= render "shared/tag_pills_static", record: pc %>
+              </div>
+
+              <!-- 説明（ピルの下） -->
+              <p class="text-sm text-slate-500 mt-2"><%= truncate(pc.description, length: 120) %></p>
             </div>
 
             <!-- 右：メトリクス（いいね数・利用数） -->

--- a/app/views/pre_codes/show.html.erb
+++ b/app/views/pre_codes/show.html.erb
@@ -15,6 +15,14 @@
     </div>
   </section>
 
+  <!-- タグ -->
+  <section>
+    <h2 class="text-sm font-semibold tracking-wider text-slate-500">タグ</h2>
+    <div class="mt-1 flex flex-wrap">
+      <%= render "shared/tag_pills_static", record: @pre_code %>
+    </div>
+  </section>
+
   <!-- コードの説明 -->
   <section>
     <h2 class="text-sm font-semibold tracking-wider text-slate-500">コードの説明</h2>

--- a/app/views/shared/_tag_filter.html.erb
+++ b/app/views/shared/_tag_filter.html.erb
@@ -1,0 +1,22 @@
+<%# 目次ページ上部に置くタグ検索フォーム（GET ...?tags= に送る） %>
+<% target_url = local_assigns[:url] || pre_codes_path %>
+
+<%= form_with url: target_url,
+              method: :get,
+              local: true,
+              html: { class: "mb-0 ml-auto flex gap-2 items-center" } do %>
+  <input type="text"
+         name="tags"
+         value="<%= params[:tags].to_s %>"
+         placeholder="タグ検索（例: ruby, array）"
+         class="px-3 py-2 rounded ring-1 ring-slate-300 w-64"
+         data-controller="tag-token"
+         data-action="input->tag-token#suggest" />
+
+  <button type="submit"
+          class="px-3 py-2 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]">
+    検索
+  </button>
+<% end %>
+
+<div id="tag-suggest" class="mt-1 text-sm text-slate-500"></div>

--- a/app/views/shared/_tag_pills.html.erb
+++ b/app/views/shared/_tag_pills.html.erb
@@ -1,0 +1,11 @@
+<%# record は .tags を持つ（PreCode など） %>
+<div class="flex flex-wrap gap-1.5">
+  <% Array(record.tags).each do |t| %>
+    <% bg = tag_rgba_bg(t.color) %>
+    <%= link_to t.name,
+        pre_codes_path(tags: t.name),
+        class: "inline-flex items-center rounded-full px-2 py-0.5
+                text-xs font-medium border hover:opacity-90 transition",
+        style: "color: #{t.color}; border-color: #{t.color}; background-color: #{bg}" %>
+  <% end %>
+</div>

--- a/app/views/shared/_tag_pills_static.html.erb
+++ b/app/views/shared/_tag_pills_static.html.erb
@@ -1,0 +1,9 @@
+<%# record は .tags を持つ（PreCode など） %>
+<div class="flex flex-wrap gap-1.5">
+  <% Array(record.tags).each do |t| %>
+    <% bg = tag_rgba_bg(t.color) %>
+    <%= content_tag :span, t.name,
+          class: "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium border",
+          style: "color: #{t.color}; border-color: #{t.color}; background-color: #{bg}" %>
+  <% end %>
+</div>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Tags#index</h1>
+<p>Find me in app/views/tags/index.html.erb</p>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Tags#show</h1>
+<p>Find me in app/views/tags/show.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,9 @@ Rails.application.routes.draw do
   resources :likes,      only: %i[create destroy]
   resources :used_codes, only: %i[create]
 
+  # タグ
+  resources :tags, only: %i[index show]
+
   # Code Editor
   root "editor#index"
   get  "/editor", to: "editor#index",  as: :editor
@@ -59,6 +62,10 @@ Rails.application.routes.draw do
         patch :toggle_editor
         patch :toggle_ban
       end
+    end
+
+    resources :tags, only: %i[index destroy] do
+      post :merge, on: :collection
     end
   end
 

--- a/db/migrate/20250926085329_create_tags.rb
+++ b/db/migrate/20250926085329_create_tags.rb
@@ -1,0 +1,30 @@
+class CreateTags < ActiveRecord::Migration[8.0]
+  def change
+    create_table :tags do |t|
+      # 表示名（アプリ側のバリデーションも併用）
+      t.string  :name,       null: false, limit: 30
+
+      # 正規化名：NFKC→strip→squeeze_space→downcase（アプリ側で生成）
+      t.string  :name_norm,  null: false, limit: 60
+
+      # URL 用 slug（ローマ字化＋a-z0-9-）
+      t.string  :slug,       null: false, limit: 80
+
+      # "#RRGGBB"（未指定はアプリ側で自動色）
+      t.string  :color,      limit: 7
+
+      # counter_cache
+      t.integer :taggings_count, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :tags, :name_norm, unique: true
+    add_index :tags, :slug,      unique: true
+
+    # PostgreSQL: 色の形式チェック（NULL は許可）
+    add_check_constraint :tags,
+                         "color IS NULL OR color ~ '^#[0-9A-Fa-f]{6}$'",
+                         name: "tags_color_hex"
+  end
+end

--- a/db/migrate/20250926085337_create_pre_code_taggings.rb
+++ b/db/migrate/20250926085337_create_pre_code_taggings.rb
@@ -1,0 +1,14 @@
+class CreatePreCodeTaggings < ActiveRecord::Migration[8.0]
+  def change
+    create_table :pre_code_taggings do |t|
+      t.references :pre_code, null: false, foreign_key: { on_delete: :cascade }
+      t.references :tag,      null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :pre_code_taggings, [ :pre_code_id, :tag_id ],
+              unique: true,
+              name: "index_pre_code_taggings_on_pre_code_id_and_tag_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_26_083054) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_26_085337) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -85,6 +85,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_26_083054) do
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
+  create_table "pre_code_taggings", force: :cascade do |t|
+    t.bigint "pre_code_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["pre_code_id", "tag_id"], name: "index_pre_code_taggings_on_pre_code_id_and_tag_id", unique: true
+    t.index ["pre_code_id"], name: "index_pre_code_taggings_on_pre_code_id"
+    t.index ["tag_id"], name: "index_pre_code_taggings_on_tag_id"
+  end
+
   create_table "pre_codes", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "title", null: false
@@ -108,6 +118,19 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_26_083054) do
     t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
     t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
     t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", limit: 30, null: false
+    t.string "name_norm", limit: 60, null: false
+    t.string "slug", limit: 80, null: false
+    t.string "color", limit: 7
+    t.integer "taggings_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name_norm"], name: "index_tags_on_name_norm", unique: true
+    t.index ["slug"], name: "index_tags_on_slug", unique: true
+    t.check_constraint "color IS NULL OR color::text ~ '^#[0-9A-Fa-f]{6}$'::text", name: "tags_color_hex"
   end
 
   create_table "used_codes", force: :cascade do |t|
@@ -147,6 +170,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_26_083054) do
   add_foreign_key "book_sections", "books"
   add_foreign_key "likes", "pre_codes"
   add_foreign_key "likes", "users"
+  add_foreign_key "pre_code_taggings", "pre_codes", on_delete: :cascade
+  add_foreign_key "pre_code_taggings", "tags"
   add_foreign_key "pre_codes", "users"
   add_foreign_key "used_codes", "pre_codes"
   add_foreign_key "used_codes", "users"

--- a/spec/factories/pre_code_taggings.rb
+++ b/spec/factories/pre_code_taggings.rb
@@ -1,0 +1,7 @@
+# spec/factories/pre_code_taggings.rb
+FactoryBot.define do
+  factory :pre_code_tagging do
+    association :pre_code
+    association :tag
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,6 @@
+# spec/factories/tags.rb
+FactoryBot.define do
+  factory :tag do
+    sequence(:name) { |n| "tag#{n}" }
+  end
+end

--- a/spec/models/pre_code_tagging_spec.rb
+++ b/spec/models/pre_code_tagging_spec.rb
@@ -1,0 +1,10 @@
+# spec/models/pre_code_tagging_spec.rb
+require "rails_helper"
+RSpec.describe PreCodeTagging, type: :model do
+  it "pre_code と tag の組が一意" do
+    pc = create(:pre_code)
+    tag = create(:tag)
+    create(:pre_code_tagging, pre_code: pc, tag: tag)
+    expect { create(:pre_code_tagging, pre_code: pc, tag: tag) }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,8 @@
+# spec/models/tag_spec.rb
+require "rails_helper"
+RSpec.describe Tag, type: :model do
+  it "name_norm が一意になる" do
+    create(:tag, name: "Ruby")
+    expect { create(:tag, name: " ruby ") }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+end

--- a/spec/requests/admin/tags_spec.rb
+++ b/spec/requests/admin/tags_spec.rb
@@ -1,0 +1,20 @@
+# spec/requests/admin/tags_spec.rb
+require "rails_helper"
+RSpec.describe "Admin::Tags", type: :request do
+  let(:admin) { create(:user, admin: true) }
+  before { sign_in admin }
+
+  it "統合できる" do
+    from = create(:tag, name: "ruby")
+    to   = create(:tag, name: "ruby-lang")
+    pc = create(:pre_code, user: admin); pc.tags << from
+    post merge_admin_tags_path, params: { from_id: from.id, to_id: to.id }
+    expect(response).to redirect_to(admin_tags_path)
+    expect(pc.reload.tags).to include(to)
+  end
+
+  it "未使用タグは削除できる" do
+    t = create(:tag, name: "unused")
+    expect { delete admin_tag_path(t) }.to change(Tag, :count).by(-1)
+  end
+end

--- a/spec/requests/pre_codes_tags_spec.rb
+++ b/spec/requests/pre_codes_tags_spec.rb
@@ -1,0 +1,41 @@
+# spec/requests/pre_codes_tags_spec.rb
+require "rails_helper"
+RSpec.describe "PreCode tags", type: :request do
+  let(:user) { create(:user) }
+
+  describe "AND検索" do
+    it "選択したタグすべてを含むものだけ返る" do
+      sign_in user
+      t1 = create(:tag, name: "ruby")
+      t2 = create(:tag, name: "array")
+      pc_ok  = create(:pre_code, user:)
+      pc_ng1 = create(:pre_code, user:)
+      pc_ng2 = create(:pre_code, user:)
+      pc_ok.tags  << [ t1, t2 ]
+      pc_ng1.tags << [ t1 ]
+      pc_ng2.tags << [ t2 ]
+
+      get pre_codes_path, params: { tags: "ruby,array" }
+      expect(response.body).to include(pc_ok.title)
+      expect(response.body).not_to include(pc_ng1.title)
+      expect(response.body).not_to include(pc_ng2.title)
+    end
+  end
+
+  describe "作成/更新" do
+    before { sign_in user }
+
+    it "作成時にタグ付与できる" do
+      post pre_codes_path, params: { pre_code: attributes_for(:pre_code), tag_names: "ruby, array" }
+      pc = PreCode.last
+      expect(pc.tags.map(&:name_norm)).to match_array(%w[ruby array])
+    end
+
+    it "更新でタグ集合が置き換わる" do
+      pc = create(:pre_code, user:)
+      post pre_codes_path, params: { pre_code: attributes_for(:pre_code), tag_names: "a,b" } if pc.nil?
+      patch pre_code_path(pc), params: { pre_code: { title: pc.title, body: pc.body }, tag_names: "x,y" }
+      expect(pc.reload.tags.map(&:name_norm)).to match_array(%w[x y])
+    end
+  end
+end

--- a/spec/services/tagging_service_spec.rb
+++ b/spec/services/tagging_service_spec.rb
@@ -1,0 +1,18 @@
+# spec/services/tagging_service_spec.rb
+require "rails_helper"
+RSpec.describe TaggingService do
+  let(:user) { create(:user) }
+  let(:pc)   { create(:pre_code, user:) }
+
+  it "既存タグを再利用して付与" do
+    t = create(:tag, name: "Ruby")
+    TaggingService.new(pc, current_user: user).apply!([ "ruby" ])
+    expect(pc.tags).to match_array([ t ])
+  end
+
+  it "新規タグを作成して付与（最大10個に丸める）" do
+    names = (1..12).map { |i| "t#{i}" }
+    TaggingService.new(pc, current_user: user).apply!(names)
+    expect(pc.tags.count).to eq(10)
+  end
+end


### PR DESCRIPTION
### 概要
PreCode にタグ機能を追加し、登録・検索・表示・管理（統合/削除）まで一通り実装した。

**作業内容**

- Tag / PreCodeTagging の導入（正規化名・slug・color・counter_cache）と関連・バリデーションを実装
- TaggingService で作成/更新時のタグ差分適用（最大10件・既存再利用）を実装、AND検索を PreCodes#index に追加
- 共有ビュー（タグピル／静的ピル／タグ検索フォーム）を作成し、PreCode/CodeLibrary 画面へ適用してUIを整備
- 管理画面 Admin::Tags を追加（一覧・ID表示・検索・未使用削除・統合：from→to 付け替え／重複除去）
- RSpec を追加（モデル一意制約、サービス、PreCode の検索/作成/更新、Admin タグ統合・削除）