### PR TITLE
教本連動クイズMVPを実装：3テーブル追加、一般回答フロー/結果集計、管理CRUD、最小ビューとRSpec

### DIFF
--- a/app/controllers/admin/quiz_questions_controller.rb
+++ b/app/controllers/admin/quiz_questions_controller.rb
@@ -1,0 +1,44 @@
+# app/controllers/admin/quiz_questions_controller.rb
+class Admin::QuizQuestionsController < Admin::BaseController
+  layout "admin"
+
+  def index
+    @questions = QuizQuestion.includes(:quiz, :quiz_section).order(updated_at: :desc).page(params[:page])
+  end
+
+  def new    = @question = QuizQuestion.new
+  def edit   = @question = QuizQuestion.find(params[:id])
+
+  def create
+    @question = QuizQuestion.new(question_params)
+    if @question.save
+      redirect_to admin_quiz_questions_path, notice: "作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @question = QuizQuestion.find(params[:id])
+    if @question.update(question_params)
+      redirect_to admin_quiz_questions_path, notice: "更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    QuizQuestion.find(params[:id]).destroy
+    redirect_to admin_quiz_questions_path, notice: "削除しました"
+  end
+
+  private
+
+  def question_params
+    params.require(:quiz_question).permit(
+      :quiz_id, :quiz_section_id, :question,
+      :choice1, :choice2, :choice3, :choice4,
+      :correct_choice, :explanation, :position
+    )
+  end
+end

--- a/app/controllers/admin/quiz_sections_controller.rb
+++ b/app/controllers/admin/quiz_sections_controller.rb
@@ -1,0 +1,40 @@
+# app/controllers/admin/quiz_sections_controller.rb
+class Admin::QuizSectionsController < Admin::BaseController
+  layout "admin"
+
+  def index
+    @sections = QuizSection.includes(:quiz).order(updated_at: :desc).page(params[:page])
+  end
+
+  def new    = @section = QuizSection.new
+  def edit   = @section = QuizSection.find(params[:id])
+
+  def create
+    @section = QuizSection.new(section_params)
+    if @section.save
+      redirect_to admin_quiz_sections_path, notice: "作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @section = QuizSection.find(params[:id])
+    if @section.update(section_params)
+      redirect_to admin_quiz_sections_path, notice: "更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    QuizSection.find(params[:id]).destroy
+    redirect_to admin_quiz_sections_path, notice: "削除しました"
+  end
+
+  private
+
+  def section_params
+    params.require(:quiz_section).permit(:quiz_id, :heading, :is_free, :position)
+  end
+end

--- a/app/controllers/admin/quizzes_controller.rb
+++ b/app/controllers/admin/quizzes_controller.rb
@@ -1,0 +1,40 @@
+# app/controllers/admin/quizzes_controller.rb
+class Admin::QuizzesController < Admin::BaseController
+  layout "admin"
+
+  def index
+    @quizzes = Quiz.order(position: :asc, updated_at: :desc).page(params[:page])
+  end
+
+  def new    = @quiz = Quiz.new
+  def edit   = @quiz = Quiz.find(params[:id])
+
+  def create
+    @quiz = Quiz.new(quiz_params)
+    if @quiz.save
+      redirect_to admin_quizzes_path, notice: "クイズを作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @quiz = Quiz.find(params[:id])
+    if @quiz.update(quiz_params)
+      redirect_to admin_quizzes_path, notice: "更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    Quiz.find(params[:id]).destroy
+    redirect_to admin_quizzes_path, notice: "削除しました"
+  end
+
+  private
+
+  def quiz_params
+    params.require(:quiz).permit(:title, :description, :position)
+  end
+end

--- a/app/controllers/quizzes/sections/questions_controller.rb
+++ b/app/controllers/quizzes/sections/questions_controller.rb
@@ -1,0 +1,52 @@
+# app/controllers/quizzes/sections/questions_controller.rb
+class Quizzes::Sections::QuestionsController < ApplicationController
+  before_action :set_quiz_and_section
+  before_action :ensure_access!
+
+  def show
+    @question = @section.quiz_questions.find(params[:id])
+    @next_q   = @section.quiz_questions.where("position > ?", @question.position).order(:position).first
+    @prev_q   = @section.quiz_questions.where("position < ?", @question.position).order(position: :desc).first
+    @answer_state = scores[@question.id.to_s] # true/false/nil
+  end
+
+  # POST /.../questions/:id/answer
+  def answer
+    @question = @section.quiz_questions.find(params[:id])
+    selected  = params[:choice].to_i
+    correct   = (selected == @question.correct_choice)
+
+    scores[@question.id.to_s] = correct
+
+    # ★ PRG: GET にリダイレクトして解説を表示
+    redirect_to answer_page_quiz_section_question_path(@quiz, @section, @question,
+                   choice: selected),
+                status: :see_other
+  end
+
+  # GET /.../questions/:id/answer_page
+  def answer_page
+    @question = @section.quiz_questions.find(params[:id])
+    @next_q   = @section.quiz_questions.where("position > ?", @question.position).order(:position).first
+    render :answer
+  end
+
+  private
+
+  def set_quiz_and_section
+    @quiz    = Quiz.find(params[:quiz_id])
+    @section = @quiz.quiz_sections.find(params[:section_id])
+  end
+
+  def ensure_access!
+    return if @section.is_free
+    return if respond_to?(:logged_in?, true) ? send(:logged_in?) : current_user.present?
+    store_location(quiz_section_path(@quiz, @section)) if respond_to?(:store_location, true)
+    redirect_to new_session_path, alert: "このクイズを解くにはログインが必要です"
+  end
+
+  def scores
+    session[:quiz_scores] ||= {}
+    session[:quiz_scores][@section.id.to_s] ||= {}
+  end
+end

--- a/app/controllers/quizzes/sections_controller.rb
+++ b/app/controllers/quizzes/sections_controller.rb
@@ -1,0 +1,47 @@
+# app/controllers/quizzes/sections_controller.rb
+class Quizzes::SectionsController < ApplicationController
+  before_action :set_quiz
+  before_action :set_section
+  before_action :ensure_access!
+
+  def index
+    redirect_to quiz_section_path(@quiz, @quiz.quiz_sections.first) and return
+  end
+
+  def show
+    # 最初の問題へ誘導
+    q = @section.quiz_questions.first
+    if q
+      redirect_to quiz_section_question_path(@quiz, @section, q)
+    else
+      render :empty # 問題未登録用（任意）
+    end
+  end
+
+  def result
+    scores = session_scores_for(@section.id)
+    @total = @section.quiz_questions.count
+    @correct = scores.values.count(true)
+  end
+
+  private
+
+  def set_quiz    = @quiz    = Quiz.find(params[:quiz_id])
+  def set_section = @section = @quiz.quiz_sections.find(params[:id])
+
+  # FREE 以外はログイン必須
+  def ensure_access!
+    return if @section.is_free
+    return if respond_to?(:logged_in?, true) ? send(:logged_in?) : current_user.present?
+
+    # 既存のストアロケーションヘルパがあれば利用
+    store_location(quiz_section_path(@quiz, @section)) if respond_to?(:store_location, true)
+    redirect_to new_session_path, alert: "このクイズを解くにはログインが必要です"
+  end
+
+  # セクション毎のスコア保存領域（セッション）
+  def session_scores_for(section_id)
+    session[:quiz_scores] ||= {}
+    session[:quiz_scores][section_id.to_s] ||= {}
+  end
+end

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,0 +1,11 @@
+# app/controllers/quizzes_controller.rb
+class QuizzesController < ApplicationController
+  def index
+    @quizzes = Quiz.order(position: :asc, updated_at: :desc).page(params[:page])
+  end
+
+  def show
+    @quiz = Quiz.includes(:quiz_sections).find(params[:id])
+    @sections = @quiz.quiz_sections # position順スコープ済
+  end
+end

--- a/app/helpers/admin/quiz_questions_helper.rb
+++ b/app/helpers/admin/quiz_questions_helper.rb
@@ -1,0 +1,2 @@
+module Admin::QuizQuestionsHelper
+end

--- a/app/helpers/admin/quiz_sections_helper.rb
+++ b/app/helpers/admin/quiz_sections_helper.rb
@@ -1,0 +1,2 @@
+module Admin::QuizSectionsHelper
+end

--- a/app/helpers/admin/quizzes_helper.rb
+++ b/app/helpers/admin/quizzes_helper.rb
@@ -1,0 +1,2 @@
+module Admin::QuizzesHelper
+end

--- a/app/helpers/quizzes/sections/questions_helper.rb
+++ b/app/helpers/quizzes/sections/questions_helper.rb
@@ -1,0 +1,2 @@
+module Quizzes::Sections::QuestionsHelper
+end

--- a/app/helpers/quizzes/sections_helper.rb
+++ b/app/helpers/quizzes/sections_helper.rb
@@ -1,0 +1,2 @@
+module Quizzes::SectionsHelper
+end

--- a/app/helpers/quizzes_helper.rb
+++ b/app/helpers/quizzes_helper.rb
@@ -1,0 +1,6 @@
+# app/helpers/quizzes_helper.rb
+module QuizzesHelper
+  def choice_label(question, n)
+    question.public_send("choice#{n}")
+  end
+end

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -1,0 +1,18 @@
+# app/models/quiz.rb
+class Quiz < ApplicationRecord
+  has_many :quiz_sections, -> { order(:position) }, dependent: :destroy
+  has_many :quiz_questions, dependent: :destroy
+
+  validates :title, presence: true, length: { maximum: 100 }
+  validates :description, presence: true, length: { maximum: 500 }
+  validates :position, presence: true,
+                       numericality: { only_integer: true, greater_than: 0 }
+
+  before_validation :set_default_position, on: :create
+
+  private
+
+  def set_default_position
+    self.position ||= (Quiz.maximum(:position) || 0) + 1
+  end
+end

--- a/app/models/quiz_question.rb
+++ b/app/models/quiz_question.rb
@@ -1,0 +1,16 @@
+# app/models/quiz_question.rb
+class QuizQuestion < ApplicationRecord
+  belongs_to :quiz
+  belongs_to :quiz_section
+
+  validates :question, :explanation, presence: true
+  with_options presence: true do
+    validates :choice1
+    validates :choice2
+    validates :choice3
+    validates :choice4
+  end
+  validates :correct_choice, presence: true, inclusion: { in: 1..4 }
+  validates :position, presence: true,
+                       numericality: { only_integer: true, greater_than: 0 }
+end

--- a/app/models/quiz_section.rb
+++ b/app/models/quiz_section.rb
@@ -1,0 +1,17 @@
+# app/models/quiz_section.rb
+class QuizSection < ApplicationRecord
+  belongs_to :quiz, touch: true
+  has_many :quiz_questions, -> { order(:position) }, dependent: :destroy
+
+  validates :heading, presence: true, length: { maximum: 100 }
+  validates :position, presence: true,
+                       numericality: { only_integer: true, greater_than: 0 }
+  validates :is_free, inclusion: { in: [ true, false ] }
+
+  scope :free,  -> { where(is_free: true)  }
+  scope :paid,  -> { where(is_free: false) }
+
+  # 前後ナビ（同一 quiz 内）
+  def previous = quiz.quiz_sections.where("position < ?", position).order(position: :desc).first
+  def next     = quiz.quiz_sections.where("position > ?", position).order(position: :asc).first
+end

--- a/app/views/admin/quiz_questions/_form.html.erb
+++ b/app/views/admin/quiz_questions/_form.html.erb
@@ -1,0 +1,75 @@
+<%= form_with model: @question,
+              url: (@question.new_record? ? admin_quiz_questions_path : admin_quiz_question_path(@question)),
+              method: (@question.new_record? ? :post : :patch),
+              local: true,
+              class: "space-y-4" do |f| %>
+  <% if @question.errors.any? %>
+    <div class="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">
+      <p><strong><%= @question.errors.count %></strong> 件のエラーがあります：</p>
+      <ul class="list-disc pl-5 mt-1">
+        <% @question.errors.full_messages.each do |m| %><li><%= m %></li><% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :quiz_id, "Quiz", class: "block text-sm text-slate-600" %>
+    <%= f.collection_select :quiz_id, Quiz.order(:position), :id, :title,
+          {}, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2",
+          data: { controller: "quiz-form" } %>
+  </div>
+
+  <div>
+    <%= f.label :quiz_section_id, "Section", class: "block text-sm text-slate-600" %>
+    <%= f.collection_select :quiz_section_id, QuizSection.includes(:quiz).order("quizzes.position, quiz_sections.position"),
+          :id, ->(s){ "[#{s.quiz.title}] #{s.heading}" },
+          {}, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+  </div>
+
+  <div>
+    <%= f.label :question, "問題文", class: "block text-sm text-slate-600" %>
+    <%= f.text_area :question, rows: 3, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+    <div>
+      <%= f.label :choice1, "選択肢1", class: "block text-sm text-slate-600" %>
+      <%= f.text_field :choice1, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :choice2, "選択肢2", class: "block text-sm text-slate-600" %>
+      <%= f.text_field :choice2, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :choice3, "選択肢3", class: "block text-sm text-slate-600" %>
+      <%= f.text_field :choice3, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :choice4, "選択肢4", class: "block text-sm text-slate-600" %>
+      <%= f.text_field :choice4, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-2 gap-3">
+    <div>
+      <%= f.label :correct_choice, "正解（1..4）", class: "block text-sm text-slate-600" %>
+      <%= f.number_field :correct_choice, min: 1, max: 4, class: "w-32 rounded ring-1 ring-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :position, "位置", class: "block text-sm text-slate-600" %>
+      <%= f.number_field :position, min: 1, step: 1, class: "w-32 rounded ring-1 ring-slate-300 px-3 py-2" %>
+    </div>
+  </div>
+
+  <div>
+    <%= f.label :explanation, "解説", class: "block text-sm text-slate-600" %>
+    <%= f.text_area :explanation, rows: 4, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+  </div>
+
+  <div>
+    <%= f.submit (@question.new_record? ? "作成する" : "更新する"),
+          class: "px-4 py-2 rounded bg-slate-900 text-white" %>
+    <%= link_to "一覧に戻る", admin_quiz_questions_path,
+          class: "ml-2 px-4 py-2 rounded ring-1 ring-slate-300" %>
+  </div>
+<% end %>

--- a/app/views/admin/quiz_questions/edit.html.erb
+++ b/app/views/admin/quiz_questions/edit.html.erb
@@ -1,0 +1,2 @@
+<h1 class="text-xl font-bold mb-4">Quiz 問題を編集</h1>
+<%= render "form" %>

--- a/app/views/admin/quiz_questions/index.html.erb
+++ b/app/views/admin/quiz_questions/index.html.erb
@@ -1,0 +1,40 @@
+<h1 class="text-xl font-bold mb-4">Quiz Questions</h1>
+
+<div class="mb-3">
+  <%= link_to "＋ 新規作成", new_admin_quiz_question_path,
+        class: "px-3 py-2 rounded bg-slate-900 text-white" %>
+</div>
+
+<table class="w-full text-sm border rounded overflow-hidden">
+  <thead class="bg-slate-50">
+    <tr>
+      <th class="p-2 text-right w-20">ID</th>
+      <th class="p-2">Quiz</th>
+      <th class="p-2">Section</th>
+      <th class="p-2">Q（先頭20字）</th>
+      <th class="p-2 w-20">正解</th>
+      <th class="p-2 w-20">位置</th>
+      <th class="p-2 w-40"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @questions.each do |q| %>
+      <tr class="border-t">
+        <td class="p-2 text-right font-mono"><%= q.id %></td>
+        <td class="p-2"><%= q.quiz.title %></td>
+        <td class="p-2"><%= q.quiz_section.heading %></td>
+        <td class="p-2"><%= truncate(q.question, length: 20) %></td>
+        <td class="p-2"><%= q.correct_choice %></td>
+        <td class="p-2"><%= q.position %></td>
+        <td class="p-2 text-right">
+          <%= link_to "編集", edit_admin_quiz_question_path(q), class: "underline mr-3" %>
+          <%= link_to "削除", admin_quiz_question_path(q),
+                data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
+                class: "underline text-red-600" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<div class="mt-4"><%= paginate @questions if respond_to?(:paginate) %></div>

--- a/app/views/admin/quiz_questions/new.html.erb
+++ b/app/views/admin/quiz_questions/new.html.erb
@@ -1,0 +1,2 @@
+<h1 class="text-xl font-bold mb-4">Quiz 問題を作成</h1>
+<%= render "form" %>

--- a/app/views/admin/quiz_sections/_form.html.erb
+++ b/app/views/admin/quiz_sections/_form.html.erb
@@ -1,0 +1,45 @@
+<%= form_with model: @section,
+              url: (@section.new_record? ? admin_quiz_sections_path : admin_quiz_section_path(@section)),
+              method: (@section.new_record? ? :post : :patch),
+              local: true,
+              class: "space-y-4" do |f| %>
+  <% if @section.errors.any? %>
+    <div class="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">
+      <p><strong><%= @section.errors.count %></strong> 件のエラーがあります：</p>
+      <ul class="list-disc pl-5 mt-1">
+        <% @section.errors.full_messages.each do |m| %><li><%= m %></li><% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :quiz_id, "Quiz", class: "block text-sm text-slate-600" %>
+    <%= f.collection_select :quiz_id, Quiz.order(:position), :id, :title,
+          {}, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+  </div>
+
+  <div>
+    <%= f.label :heading, "見出し", class: "block text-sm text-slate-600" %>
+    <%= f.text_field :heading, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+  </div>
+
+  <div>
+    <label class="inline-flex items-center gap-2">
+      <%= f.check_box :is_free %>
+      <span>FREE（未ログインでも解ける）</span>
+    </label>
+  </div>
+
+  <div>
+    <%= f.label :position, "位置", class: "block text-sm text-slate-600" %>
+    <%= f.number_field :position, min: 1, step: 1,
+          class: "w-40 rounded ring-1 ring-slate-300 px-3 py-2" %>
+  </div>
+
+  <div>
+    <%= f.submit (@section.new_record? ? "作成する" : "更新する"),
+          class: "px-4 py-2 rounded bg-slate-900 text-white" %>
+    <%= link_to "一覧に戻る", admin_quiz_sections_path,
+          class: "ml-2 px-4 py-2 rounded ring-1 ring-slate-300" %>
+  </div>
+<% end %>

--- a/app/views/admin/quiz_sections/edit.html.erb
+++ b/app/views/admin/quiz_sections/edit.html.erb
@@ -1,0 +1,2 @@
+<h1 class="text-xl font-bold mb-4">Quiz セクションを編集</h1>
+<%= render "form" %>

--- a/app/views/admin/quiz_sections/index.html.erb
+++ b/app/views/admin/quiz_sections/index.html.erb
@@ -1,0 +1,40 @@
+<h1 class="text-xl font-bold mb-4">Quiz Sections</h1>
+
+<div class="mb-3">
+  <%= link_to "＋ 新規作成", new_admin_quiz_section_path,
+        class: "px-3 py-2 rounded bg-slate-900 text-white" %>
+</div>
+
+<table class="w-full text-sm border rounded overflow-hidden">
+  <thead class="bg-slate-50">
+    <tr>
+      <th class="p-2 text-right w-20">ID</th>
+      <th class="p-2">Quiz</th>
+      <th class="p-2">見出し</th>
+      <th class="p-2 w-20">FREE</th>
+      <th class="p-2 w-20">位置</th>
+      <th class="p-2 w-40">更新</th>
+      <th class="p-2 w-40"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @sections.each do |s| %>
+      <tr class="border-t">
+        <td class="p-2 text-right font-mono"><%= s.id %></td>
+        <td class="p-2"><%= s.quiz.title %></td>
+        <td class="p-2"><%= s.heading %></td>
+        <td class="p-2"><%= s.is_free ? "✔︎" : "" %></td>
+        <td class="p-2"><%= s.position %></td>
+        <td class="p-2"><%= l s.updated_at, format: :short %></td>
+        <td class="p-2 text-right">
+          <%= link_to "編集", edit_admin_quiz_section_path(s), class: "underline mr-3" %>
+          <%= link_to "削除", admin_quiz_section_path(s),
+                data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
+                class: "underline text-red-600" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<div class="mt-4"><%= paginate @sections if respond_to?(:paginate) %></div>

--- a/app/views/admin/quiz_sections/new.html.erb
+++ b/app/views/admin/quiz_sections/new.html.erb
@@ -1,0 +1,2 @@
+<h1 class="text-xl font-bold mb-4">Quiz セクションを作成</h1>
+<%= render "form" %>

--- a/app/views/admin/quizzes/_form.html.erb
+++ b/app/views/admin/quizzes/_form.html.erb
@@ -1,0 +1,38 @@
+<!-- app/views/admin/quizzes/_form.html.erb -->
+<%= form_with model: @quiz,
+              url: (@quiz.new_record? ? admin_quizzes_path : admin_quiz_path(@quiz)),
+              method: (@quiz.new_record? ? :post : :patch),
+              local: true,
+              class: "space-y-4" do |f| %>
+  <% if @quiz.errors.any? %>
+    <div class="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">
+      <p><strong><%= @quiz.errors.count %></strong> 件のエラーがあります：</p>
+      <ul class="list-disc pl-5 mt-1">
+        <% @quiz.errors.full_messages.each do |m| %><li><%= m %></li><% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :title, class: "block text-sm text-slate-600" %>
+    <%= f.text_field :title, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+  </div>
+
+  <div>
+    <%= f.label :description, class: "block text-sm text-slate-600" %>
+    <%= f.text_area :description, rows: 3, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+  </div>
+
+  <div>
+    <%= f.label :position, class: "block text-sm text-slate-600" %>
+    <%= f.number_field :position, min: 1, step: 1,
+          class: "w-40 rounded ring-1 ring-slate-300 px-3 py-2" %>
+  </div>
+
+  <div>
+    <%= f.submit (@quiz.new_record? ? "作成する" : "更新する"),
+          class: "px-4 py-2 rounded bg-slate-900 text-white" %>
+    <%= link_to "一覧に戻る", admin_quizzes_path,
+          class: "ml-2 px-4 py-2 rounded ring-1 ring-slate-300" %>
+  </div>
+<% end %>

--- a/app/views/admin/quizzes/edit.html.erb
+++ b/app/views/admin/quizzes/edit.html.erb
@@ -1,0 +1,3 @@
+<!-- app/views/admin/quizzes/edit.html.erb -->
+<h1 class="text-xl font-bold mb-4">Quiz を編集</h1>
+<%= render "form" %>

--- a/app/views/admin/quizzes/index.html.erb
+++ b/app/views/admin/quizzes/index.html.erb
@@ -1,0 +1,37 @@
+<!-- app/views/admin/quizzes/index.html.erb -->
+<h1 class="text-xl font-bold mb-4">Quizzes</h1>
+
+<div class="mb-3">
+  <%= link_to "＋ 新規作成", new_admin_quiz_path,
+        class: "px-3 py-2 rounded bg-slate-900 text-white" %>
+</div>
+
+<table class="w-full text-sm border rounded overflow-hidden">
+  <thead class="bg-slate-50">
+    <tr>
+      <th class="p-2 text-right w-20">ID</th>
+      <th class="p-2 w-20">位置</th>
+      <th class="p-2">タイトル</th>
+      <th class="p-2 w-40">更新</th>
+      <th class="p-2 w-40"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @quizzes.each do |q| %>
+      <tr class="border-t">
+        <td class="p-2 text-right font-mono"><%= q.id %></td>
+        <td class="p-2"><%= q.position %></td>
+        <td class="p-2"><%= q.title %></td>
+        <td class="p-2"><%= l q.updated_at, format: :short %></td>
+        <td class="p-2 text-right">
+          <%= link_to "編集", edit_admin_quiz_path(q), class: "underline mr-3" %>
+          <%= link_to "削除", admin_quiz_path(q),
+                data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
+                class: "underline text-red-600" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<div class="mt-4"><%= paginate @quizzes if respond_to?(:paginate) %></div>

--- a/app/views/admin/quizzes/new.html.erb
+++ b/app/views/admin/quizzes/new.html.erb
@@ -1,0 +1,3 @@
+<!-- app/views/admin/quizzes/new.html.erb -->
+<h1 class="text-xl font-bold mb-4">Quiz を作成</h1>
+<%= render "form" %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -38,6 +38,9 @@
           <%= link_to "Users",     admin_users_path %>
           <%= link_to "PreCode管理",     admin_pre_codes_path %>
           <%= link_to "Tags",       admin_tags_path %>
+          <%= link_to "Quizzes",        admin_quizzes_path %>
+          <%= link_to "Quiz Sections",  admin_quiz_sections_path %>
+          <%= link_to "Quiz Questions", admin_quiz_questions_path %>
 
           <% if current_user&.admin? %>
             <%= button_to "Logout",

--- a/app/views/quizzes/_quiz.html.erb
+++ b/app/views/quizzes/_quiz.html.erb
@@ -1,0 +1,23 @@
+<%# app/views/quizzes/_quiz.html.erb %>
+
+<li>
+  <%= link_to quiz_path(quiz),
+    class: "block px-4 py-3 rounded-lg border bg-white hover:bg-slate-50 focus:bg-slate-50
+            flex items-center justify-between focus:outline-none focus:ring-2 focus:ring-slate-300" do %>
+
+    <div>
+      <h3 class="font-semibold text-slate-900"><%= quiz.title %></h3>
+      <p class="text-slate-500 text-sm">
+        <%= truncate(quiz.description, length: 80) %>
+      </p>
+    </div>
+
+    <div class="text-xs text-slate-500">
+      <span class="inline-flex items-center gap-1">
+        <%= heroicon "document-text", variant: :outline, options: { class: "w-4 h-4" } %>
+        <%= number_with_delimiter(quiz.quiz_sections.size) %>
+      </span>
+    </div>
+
+  <% end %>
+</li>

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -1,0 +1,14 @@
+<!-- app/views/quizzes/index.html.erb -->
+<div class="mb-6 text-center">
+  <h1 class="text-2xl font-semibold">Quizzes</h1>
+  <p class="mt-1 text-sm text-slate-500">~ 教本連動クイズ ~</p>
+</div>
+
+<ul class="divide-y divide-slate-200 rounded-lg border bg-white">
+  <%= render partial: "quiz", collection: @quizzes, as: :quiz %>
+</ul>
+
+<%# ページネーション %>
+<div class="mt-4">
+  <%= paginate @quizzes if respond_to?(:paginate) %>
+</div>

--- a/app/views/quizzes/sections/empty.html.erb
+++ b/app/views/quizzes/sections/empty.html.erb
@@ -1,0 +1,15 @@
+<!-- app/views/quizzes/sections/empty.html.erb -->
+<%# 問題未登録のセクション用 %>
+<% content_for :title, "#{@section.heading} - クイズ" %>
+
+<p class="text-sm text-slate-500 mb-2">
+  <%= link_to @quiz.title, quiz_path(@quiz) %> / <%= @section.heading %>
+</p>
+
+<div class="rounded border p-6 bg-white">
+  <h2 class="text-lg font-semibold mb-2">このセクションにはまだ問題がありません</h2>
+  <p class="text-slate-600">管理者が問題を追加するまでお待ちください。</p>
+  <div class="mt-4">
+    <%= link_to "セクション一覧に戻る", quiz_path(@quiz), class: "underline" %>
+  </div>
+</div>

--- a/app/views/quizzes/sections/questions/answer.html.erb
+++ b/app/views/quizzes/sections/questions/answer.html.erb
@@ -1,0 +1,21 @@
+<!-- app/views/quizzes/sections/questions/answer.html.erb -->
+<% correct = (params[:choice].to_i == @question.correct_choice) %>
+<div class="rounded border p-4 bg-white">
+  <p class="<%= correct ? 'text-emerald-700' : 'text-red-700' %> font-semibold">
+    <%= correct ? "正解！" : "不正解…" %>
+  </p>
+  <p class="mt-1 text-sm">正解：<%= @question.public_send("choice#{@question.correct_choice}") %></p>
+
+  <div class="mt-3 p-3 rounded bg-slate-50">
+    <h3 class="font-semibold mb-1">解説</h3>
+    <p><%= simple_format @question.explanation %></p>
+  </div>
+
+  <div class="flex justify-between mt-4">
+    <% if @next_q %>
+      <%= link_to "次の問題へ →", quiz_section_question_path(@quiz, @section, @next_q), class: "underline" %>
+    <% else %>
+      <%= link_to "結果を見る", result_quiz_section_path(@quiz, @section), class: "underline" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/quizzes/sections/questions/show.html.erb
+++ b/app/views/quizzes/sections/questions/show.html.erb
@@ -1,0 +1,43 @@
+<!-- app/views/quizzes/sections/questions/show.html.erb -->
+<% content_for :title, "#{@section.heading} - 問題" %>
+<p class="text-sm text-slate-500 mb-2">
+  <%= link_to @quiz.title, quiz_path(@quiz) %> / <%= @section.heading %>
+</p>
+
+<div class="rounded border p-4 bg-white">
+  <p class="text-slate-500 text-sm mb-1">Q<%= @question.position %></p>
+  <h2 class="text-lg font-semibold mb-3"><%= @question.question %></h2>
+
+  <%= form_with url: answer_quiz_section_question_path(@quiz, @section, @question),
+                method: :post,
+                data: { turbo: false },
+                authenticity_token: true,
+                local: true,
+                class: "space-y-2" do %>
+
+    <% (1..4).each do |i| %>
+      <% label = @question.public_send("choice#{i}") %>
+      <label class="block">
+        <%= radio_button_tag :choice, i, false, required: true %>
+        <span class="ml-2"><%= label %></span>
+      </label>
+    <% end %>
+
+    <div class="mt-3">
+      <%= submit_tag "この回答で送信", class: "px-4 py-2 rounded bg-[#CC0000] text-white" %>
+    </div>
+  <% end %>
+
+  <div class="flex justify-between mt-4">
+    <div>
+      <% if @prev_q %>
+        <%= link_to "← 前の問題", quiz_section_question_path(@quiz, @section, @prev_q), class: "underline" %>
+      <% end %>
+    </div>
+    <div>
+      <% if @next_q %>
+        <%= link_to "次の問題 →", quiz_section_question_path(@quiz, @section, @next_q), class: "underline" %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/quizzes/sections/result.html.erb
+++ b/app/views/quizzes/sections/result.html.erb
@@ -1,0 +1,9 @@
+<!-- app/views/quizzes/sections/result.html.erb -->
+<% content_for :title, "#{@section.heading} - 結果" %>
+<h1 class="text-2xl font-semibold mb-2"><%= @section.heading %> の結果</h1>
+<p class="text-xl mb-4"><span class="font-bold"><%= @correct %></span> / <%= @total %> 正解</p>
+
+<div class="flex gap-3">
+  <%= link_to "もう一度解く", quiz_section_path(@quiz, @section), class: "px-4 py-2 rounded ring-1 ring-slate-300" %>
+  <%= link_to "セクション一覧へ戻る", quiz_path(@quiz), class: "px-4 py-2 rounded ring-1 ring-slate-300" %>
+</div>

--- a/app/views/quizzes/show.html.erb
+++ b/app/views/quizzes/show.html.erb
@@ -1,0 +1,24 @@
+<!-- app/views/quizzes/show.html.erb -->
+<% content_for :title, @quiz.title %>
+<h1 class="text-3xl font-bold mb-3"><%= @quiz.title %></h1>
+<p class="text-slate-600 mb-6"><%= @quiz.description %></p>
+
+<h2 class="text-xl font-semibold mb-2">目次</h2>
+<ul class="divide-y divide-slate-200 rounded-lg border bg-white">
+  <% @sections.each do |s| %>
+    <li>
+      <%= link_to quiz_section_path(@quiz, s),
+          class: "block px-4 py-3 hover:bg-slate-50 focus:bg-slate-50 focus:outline-none" do %>
+        <div class="flex items-center justify-between">
+          <div>
+            <span class="text-slate-400 mr-3 text-sm"><%= s.position %>.</span>
+            <span class="text-slate-900"><%= s.heading %></span>
+          </div>
+          <% if s.is_free %>
+            <span class="text-xs px-2 py-0.5 bg-emerald-100 text-emerald-700 rounded">FREE</span>
+          <% end %>
+        </div>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -37,6 +37,14 @@
           </span>
         <% end %>
 
+        <%= link_to quizzes_path,
+          class: "inline-flex h-full px-4 hover:bg-[#BB0000] active:bg-[#AA0000] text-white" do %>
+          <span class="flex flex-col items-center justify-center leading-4">
+            <span class="mt-1 text-sm font-medium whitespace-nowrap">Quizzes</span>
+            <span class="text-[10px] opacity-90 whitespace-nowrap">- 教本クイズ -</span>
+          </span>
+        <% end %>
+
         <%= link_to pre_codes_path,
           class: "inline-flex h-full px-4 hover:bg-[#BB0000] active:bg-[#AA0000] text-white" do %>
           <span class="flex flex-col items-center justify-center leading-4">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,6 +13,12 @@ ja:
       long:    "%Y年%-m月%-d日 %H:%M"
       ymd_hm:  "%Y/%m/%d %H:%M"
   activerecord:
+    models:
+      pre_code: "PreCode"
+      book: "教本"
+      quiz: "クイズ"
+      quiz_section: "クイズセクション"
+      quiz_question: "クイズ問題"
     attributes:
       book_section:
         book_id: "対象の教本"
@@ -28,9 +34,37 @@ ja:
         title: "タイトル"
         description: "説明"
         position: "並び順"
-    models:
-      pre_code: "PreCode"
-      book: "教本"
+      quiz:
+        title: "タイトル"
+        description: "説明"
+        position: "位置"
+        created_at: "作成日時"
+        updated_at: "更新日時"
+
+      quiz_section:
+        quiz: "クイズ"
+        quiz_id: "クイズ"
+        heading: "見出し"
+        is_free: "FREE公開"
+        position: "位置"
+        created_at: "作成日時"
+        updated_at: "更新日時"
+
+      quiz_question:
+        quiz: "クイズ"
+        quiz_id: "クイズ"
+        quiz_section: "セクション"
+        quiz_section_id: "セクション"
+        question: "問題文"
+        choice1: "選択肢1"
+        choice2: "選択肢2"
+        choice3: "選択肢3"
+        choice4: "選択肢4"
+        correct_choice: "正解"
+        explanation: "解説"
+        position: "位置"
+        created_at: "作成日時"
+        updated_at: "更新日時"
     errors:
       models:
         book:
@@ -40,6 +74,59 @@ ja:
               not_a_number: "は数値で入力してください"
               greater_than: "は%{count}より大きい値にしてください"
               taken: "はすでに使用されています"
+        quiz:
+          attributes:
+            title:
+              blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
+            description:
+              blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
+            position:
+              blank: "を入力してください"
+              not_a_number: "は数値で入力してください"
+              not_an_integer: "は整数で入力してください"
+              greater_than: "は%{count}より大きい値にしてください"
+        quiz_section:
+          attributes:
+            quiz:
+              blank: "を選択してください"
+            heading:
+              blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
+            is_free:
+              inclusion: "は真または偽のいずれかで指定してください"
+            position:
+              blank: "を入力してください"
+              not_a_number: "は数値で入力してください"
+              not_an_integer: "は整数で入力してください"
+              greater_than: "は%{count}より大きい値にしてください"
+        quiz_question:
+          attributes:
+            quiz:
+              blank: "を選択してください"
+            quiz_section:
+              blank: "を選択してください"
+            question:
+              blank: "を入力してください"
+            explanation:
+              blank: "を入力してください"
+            choice1:
+              blank: "を入力してください"
+            choice2:
+              blank: "を入力してください"
+            choice3:
+              blank: "を入力してください"
+            choice4:
+              blank: "を入力してください"
+            correct_choice:
+              blank: "を入力してください"
+              inclusion: "は1〜4のいずれかを指定してください"
+            position:
+              blank: "を入力してください"
+              not_a_number: "は数値で入力してください"
+              not_an_integer: "は整数で入力してください"
+              greater_than: "は%{count}より大きい値にしてください"
   helpers:
     submit:
       book_section:
@@ -47,9 +134,37 @@ ja:
         update: "更新する"
       user:
         update: "更新"
+      quiz:
+        create: "作成する"
+        update: "更新する"
+      quiz_section:
+        create: "作成する"
+        update: "更新する"
+      quiz_question:
+        create: "作成する"
+        update: "更新する"
   errors:
     messages:
       blank: "を入力してください"
+      inclusion: "は一覧にありません"
+      exclusion: "は予約されています"
+      invalid: "は不正な値です"
+      confirmation: "が一致しません"
+      accepted: "に同意してください"
+      too_short: "は%{count}文字以上で入力してください"
+      too_long: "は%{count}文字以内で入力してください"
+      wrong_length: "は%{count}文字で入力してください"
+      taken: "はすでに使用されています"
+      not_a_number: "は数値で入力してください"
+      not_an_integer: "は整数で入力してください"
+      greater_than: "は%{count}より大きい値にしてください"
+      greater_than_or_equal_to: "は%{count}以上にしてください"
+      equal_to: "は%{count}にしてください"
+      less_than: "は%{count}より小さい値にしてください"
+      less_than_or_equal_to: "は%{count}以下にしてください"
+      other_than: "は%{count}以外の値にしてください"
+      odd: "は奇数を指定してください"
+      even: "は偶数を指定してください"
   bookmarks:
     limit_reached: "300件以上のブックマーク登録はできません"
   search:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,13 @@
 Rails.application.routes.draw do
+  namespace :quizzes do
+    namespace :sections do
+      get "questions/show"
+    end
+    get "sections/index"
+    get "sections/show"
+  end
+  get "quizzes/index"
+  get "quizzes/show"
   # 静的ページ
   get "help",    to: "static_pages#help"
   get "terms",   to: "static_pages#terms"
@@ -53,14 +62,50 @@ Rails.application.routes.draw do
     resources :sections, only: :show, controller: :book_sections
   end
 
+  # クイズ機能
+  resources :quizzes, only: %i[index show] do
+    resources :sections, only: %i[index show], module: :quizzes do
+      resources :questions, only: %i[show], module: :sections do
+        post :answer, on: :member
+        get  :answer_page, on: :member
+      end
+      get :result, on: :member
+    end
+  end
+
   # 管理画面
   namespace :admin do
+    get "quiz_questions/index"
+    get "quiz_questions/show"
+    get "quiz_questions/new"
+    get "quiz_questions/create"
+    get "quiz_questions/edit"
+    get "quiz_questions/update"
+    get "quiz_questions/destroy"
+    get "quiz_sections/index"
+    get "quiz_sections/show"
+    get "quiz_sections/new"
+    get "quiz_sections/create"
+    get "quiz_sections/edit"
+    get "quiz_sections/update"
+    get "quiz_sections/destroy"
+    get "quizzes/index"
+    get "quizzes/show"
+    get "quizzes/new"
+    get "quizzes/create"
+    get "quizzes/edit"
+    get "quizzes/update"
+    get "quizzes/destroy"
     root "dashboards#index"
 
     resource  :session,   only: %i[new create destroy]
     resources :books
     resources :book_sections, except: %i[show]
     resources :pre_codes, only: %i[index show edit update destroy]
+    resources :quizzes
+    resources :quiz_sections
+    resources :quiz_questions
+
     resources :users, only: [ :index, :destroy ] do
       member do
         patch :toggle_editor

--- a/db/migrate/20251001022039_create_quizzes.rb
+++ b/db/migrate/20251001022039_create_quizzes.rb
@@ -1,0 +1,11 @@
+class CreateQuizzes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :quizzes do |t|
+      t.string  :title,       null: false
+      t.text    :description, null: false
+      t.integer :position,    null: false
+      t.timestamps
+    end
+    add_index :quizzes, :position
+  end
+end

--- a/db/migrate/20251001022049_create_quiz_sections.rb
+++ b/db/migrate/20251001022049_create_quiz_sections.rb
@@ -1,0 +1,12 @@
+class CreateQuizSections < ActiveRecord::Migration[8.0]
+  def change
+    create_table :quiz_sections do |t|
+      t.references :quiz, null: false, foreign_key: true
+      t.string  :heading,  null: false
+      t.boolean :is_free,  null: false, default: false
+      t.integer :position, null: false
+      t.timestamps
+    end
+    add_index :quiz_sections, [ :quiz_id, :position ]
+  end
+end

--- a/db/migrate/20251001022057_create_quiz_questions.rb
+++ b/db/migrate/20251001022057_create_quiz_questions.rb
@@ -1,0 +1,18 @@
+class CreateQuizQuestions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :quiz_questions do |t|
+      t.references :quiz,         null: false, foreign_key: true
+      t.references :quiz_section, null: false, foreign_key: true
+      t.text    :question,        null: false
+      t.string  :choice1,         null: false
+      t.string  :choice2,         null: false
+      t.string  :choice3,         null: false
+      t.string  :choice4,         null: false
+      t.integer :correct_choice,  null: false
+      t.text    :explanation,     null: false
+      t.integer :position,        null: false
+      t.timestamps
+    end
+    add_index :quiz_questions, [ :quiz_section_id, :position ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_26_192936) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_01_022057) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -122,6 +122,44 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_26_192936) do
     t.index ["user_id"], name: "index_pre_codes_on_user_id"
   end
 
+  create_table "quiz_questions", force: :cascade do |t|
+    t.bigint "quiz_id", null: false
+    t.bigint "quiz_section_id", null: false
+    t.text "question", null: false
+    t.string "choice1", null: false
+    t.string "choice2", null: false
+    t.string "choice3", null: false
+    t.string "choice4", null: false
+    t.integer "correct_choice", null: false
+    t.text "explanation", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["quiz_id"], name: "index_quiz_questions_on_quiz_id"
+    t.index ["quiz_section_id", "position"], name: "index_quiz_questions_on_quiz_section_id_and_position"
+    t.index ["quiz_section_id"], name: "index_quiz_questions_on_quiz_section_id"
+  end
+
+  create_table "quiz_sections", force: :cascade do |t|
+    t.bigint "quiz_id", null: false
+    t.string "heading", null: false
+    t.boolean "is_free", default: false, null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["quiz_id", "position"], name: "index_quiz_sections_on_quiz_id_and_position"
+    t.index ["quiz_id"], name: "index_quiz_sections_on_quiz_id"
+  end
+
+  create_table "quizzes", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "description", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["position"], name: "index_quizzes_on_position"
+  end
+
   create_table "solid_cache_entries", id: false, force: :cascade do |t|
     t.binary "key", null: false
     t.binary "value", null: false
@@ -188,6 +226,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_26_192936) do
   add_foreign_key "pre_code_taggings", "pre_codes", on_delete: :cascade
   add_foreign_key "pre_code_taggings", "tags"
   add_foreign_key "pre_codes", "users"
+  add_foreign_key "quiz_questions", "quiz_sections"
+  add_foreign_key "quiz_questions", "quizzes"
+  add_foreign_key "quiz_sections", "quizzes"
   add_foreign_key "used_codes", "pre_codes"
   add_foreign_key "used_codes", "users"
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.13",
-        "@tailwindcss/typography": "^0.5.16",
+        "@tailwindcss/typography": "^0.5.19",
         "postcss": "^8.5.6",
         "postcss-cli": "^11.0.1",
         "tailwindcss": "^4.1.13"
@@ -419,7 +419,6 @@
       "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.13.tgz",
       "integrity": "sha512-HLgx6YSFKJT7rJqh9oJs/TkBFhxuMOfUKSBEPYwV+t78POOBsdQ7crhZLzwcH3T0UyUuOzU/GK5pk5eKr3wCiQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/node": "4.1.13",
@@ -429,15 +428,11 @@
       }
     },
     "node_modules/@tailwindcss/typography": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
-      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "lodash.castarray": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.merge": "^4.6.2",
         "postcss-selector-parser": "6.0.10"
       },
       "peerDependencies": {
@@ -1048,27 +1043,6 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
-    "node_modules/lodash.castarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
-      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/magic-string": {
       "version": "0.30.18",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
@@ -1196,7 +1170,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -1211,7 +1184,6 @@
       "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-11.0.1.tgz",
       "integrity": "sha512-0UnkNPSayHKRe/tc2YGW6XnSqqOA9eqpiRMgRlV1S6HdGi16vwJBx7lviARzbV1HpQHqLLRH3o8vTcB0cLc+5g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.3.0",
         "dependency-graph": "^1.0.0",
@@ -1414,8 +1386,7 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
       "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/tapable": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.13",
-    "@tailwindcss/typography": "^0.5.16",
+    "@tailwindcss/typography": "^0.5.19",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",
     "tailwindcss": "^4.1.13"

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,4 +1,3 @@
-// postcss.config.mjs
 export default {
   plugins: {
     "@tailwindcss/postcss": {},

--- a/spec/factories/quizzes.rb
+++ b/spec/factories/quizzes.rb
@@ -1,0 +1,28 @@
+# spec/factories/quizzes.rb
+FactoryBot.define do
+  factory :quiz do
+    sequence(:title) { |n| "Quiz #{n}" }
+    description { "desc" }
+    position { 1 }
+  end
+
+  factory :quiz_section do
+    association :quiz
+    sequence(:heading) { |n| "Section #{n}" }
+    is_free { true }
+    position { 1 }
+  end
+
+  factory :quiz_question do
+    association :quiz
+    association :quiz_section
+    sequence(:position) { |n| n }
+    question { "2+2= ?" }
+    choice1  { "1" }
+    choice2  { "2" }
+    choice3  { "3" }
+    choice4  { "4" }
+    correct_choice { 4 }
+    explanation { "2+2=4" }
+  end
+end

--- a/spec/models/quiz_question_spec.rb
+++ b/spec/models/quiz_question_spec.rb
@@ -1,0 +1,63 @@
+# spec/models/quiz_question_spec.rb
+require "rails_helper"
+
+RSpec.describe QuizQuestion, type: :model do
+  let(:quiz)    { create(:quiz) }
+  let(:section) { create(:quiz_section, quiz:) }
+
+  def build_question(attrs = {})
+    build(:quiz_question, { quiz:, quiz_section: section }.merge(attrs))
+  end
+
+  describe "基本の妥当性" do
+    it "ファクトリは有効" do
+      expect(build_question).to be_valid
+    end
+  end
+
+  describe "バリデーション" do
+    it "question/explanation は必須" do
+      q = build_question(question: "", explanation: "")
+      expect(q).to be_invalid
+      expect(q.errors[:question]).to be_present
+      expect(q.errors[:explanation]).to be_present
+    end
+
+    it "choice1..4 は全て必須" do
+      q = build_question(choice1: "", choice2: "", choice3: "", choice4: "")
+      expect(q).to be_invalid
+      expect(q.errors[:choice1]).to be_present
+      expect(q.errors[:choice2]).to be_present
+      expect(q.errors[:choice3]).to be_present
+      expect(q.errors[:choice4]).to be_present
+    end
+
+    it "correct_choice は 1..4 のみ許可（0,5,nil はNG）" do
+      [ 0, 5, nil ].each do |v|
+        q = build_question(correct_choice: v)
+        expect(q).to be_invalid
+        expect(q.errors[:correct_choice]).to be_present
+      end
+      expect(build_question(correct_choice: 1)).to be_valid
+      expect(build_question(correct_choice: 4)).to be_valid
+    end
+
+    it "position は 1 以上の整数" do
+      [ -1, 0, 1.5, nil ].each do |v|
+        q = build_question(position: v)
+        expect(q).to be_invalid
+        expect(q.errors[:position]).to be_present
+      end
+      expect(build_question(position: 1)).to be_valid
+      expect(build_question(position: 2)).to be_valid
+    end
+  end
+
+  describe "関連" do
+    it "quiz / quiz_section に属する" do
+      q = build_question
+      expect(q.quiz).to eq(quiz)
+      expect(q.quiz_section).to eq(section)
+    end
+  end
+end

--- a/spec/requests/quizzes_flow_spec.rb
+++ b/spec/requests/quizzes_flow_spec.rb
@@ -1,0 +1,73 @@
+# spec/requests/quizzes_flow_spec.rb
+require "rails_helper"
+
+RSpec.describe "Quizzes (flow)", type: :request do
+  let!(:quiz)     { create(:quiz, title: "計算クイズ") }
+  let!(:section)  { create(:quiz_section, quiz:, is_free: true, position: 1, heading: "1-1") }
+
+  # 1問目: 正解は 4 / 2問目: 正解は 3
+  let!(:q1) do
+    create(:quiz_question, quiz:, quiz_section: section,
+           position: 1, question: "2+2=?",
+           choice1: "1", choice2: "2", choice3: "3", choice4: "4",
+           correct_choice: 4, explanation: "2+2=4")
+  end
+  let!(:q2) do
+    create(:quiz_question, quiz:, quiz_section: section,
+           position: 2, question: "1+2=?",
+           choice1: "1", choice2: "2", choice3: "3", choice4: "4",
+           correct_choice: 3, explanation: "1+2=3")
+  end
+
+  describe "FREE セクションは未ログインでも解ける → 結果まで到達できる" do
+    it "質問ページ表示 → 解答（PRG追従）→ 解説に“正解/不正解”→ 結果で集計" do
+      # 最初の設問へ
+      get quiz_section_question_path(quiz, section, q1)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Q1")
+
+      # 1問目: 正解を送信（PRGなので follow_redirect! で GET に追従）
+      post answer_quiz_section_question_path(quiz, section, q1), params: { choice: 4 }
+      expect(response).to have_http_status(:see_other)
+      follow_redirect!
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("正解")        # 正解表示
+      expect(response.body).to include("解説")        # 解説表示
+
+      # 2問目: 不正解を送信 → 解説で“不正解”
+      post answer_quiz_section_question_path(quiz, section, q2), params: { choice: 1 }
+      expect(response).to have_http_status(:see_other)
+      follow_redirect!
+      expect(response.body).to include("不正解")
+
+      # 結果ページ
+      get result_quiz_section_path(quiz, section)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("1").and include("/ 2").and include("正解")
+    end
+  end
+
+  describe "セクション show は最初の問題に誘導される" do
+    it "show にアクセスすると 1問目へリダイレクト" do
+      get quiz_section_path(quiz, section)
+      expect(response).to have_http_status(:found).or have_http_status(:see_other)
+      follow_redirect!
+      # 1問目の質問文 or 番号が出ていることをざっくり確認
+      expect(response.body).to include("Q1").or include("2+2=?")
+    end
+  end
+
+  describe "有料（is_free:false）セクションは未ログインだとログイン画面へ" do
+    let!(:paid_section) { create(:quiz_section, quiz:, is_free: false, position: 2, heading: "1-2") }
+    let!(:paid_q) do
+      create(:quiz_question, quiz:, quiz_section: paid_section, position: 1)
+    end
+
+    it "質問ページにアクセスするとログインへリダイレクト" do
+      get quiz_section_question_path(quiz, paid_section, paid_q)
+      expect(response).to have_http_status(:found).or have_http_status(:see_other)
+      # アプリのログインルート名が異なる場合はここを変更してください
+      expect(response).to redirect_to(new_session_path)
+    end
+  end
+end


### PR DESCRIPTION
### 概要
教本連動クイズ機能を追加し、一般ユーザーはクイズに挑戦でき、管理者はCRUDで編集できるようにした。

**作業内容**

- Quiz / QuizSection / QuizQuestion の3モデルとマイグレーションを追加し、position順での並びやFREE制御を実装
- 一般側に回答フローを構築し、回答直後に正誤＋解説を表示、最後に結果集計を確認できるビューを作成
- 管理側にQuiz / Section / QuestionのCRUDを実装し、フォームで作成・編集・削除が可能に
- Tailwindベースの最小ビューを整備し、Booksと同様のUI構成にして一貫性を持たせた
- Request Spec と Model Spec を追加し、基本的なバリデーション・認可ガード・結果集計の動作を検証