### PR TITLE
教本&クイズの共同編集機能：権限テーブル・ロック・履歴・一般側編集フロー・管理の権限UI・RSpecを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem "gretel"
 # アイコン
 gem "heroicon-rails"
 
+# 変更履歴管理（バージョン管理・復元・監査ログ）
+gem "paper_trail", "~> 14.0"
+
 gem "image_processing", "~> 1.12"  # ActiveStorageで画像のリサイズやサムネイル生成を行うGem
 gem "mini_magick"                  # 画像処理ライブラリImageMagickのRubyラッパー
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,6 +285,9 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     ostruct (0.6.3)
+    paper_trail (14.0.0)
+      activerecord (>= 6.0)
+      request_store (~> 1.4)
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
@@ -365,6 +368,8 @@ GEM
     regexp_parser (2.11.2)
     reline (0.6.2)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     rexml (3.4.1)
     rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
@@ -521,6 +526,7 @@ DEPENDENCIES
   omniauth-github
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
+  paper_trail (~> 14.0)
   pg (~> 1.6)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/admin/editor_permissions_controller.rb
+++ b/app/controllers/admin/editor_permissions_controller.rb
@@ -1,0 +1,166 @@
+# app/controllers/admin/editor_permissions_controller.rb
+class Admin::EditorPermissionsController < Admin::BaseController
+  layout "admin"
+
+  before_action :set_permission, only: %i[show edit update destroy]
+
+  # このコントローラで許可する対象タイプ（ホワイトリスト）
+  TARGET_TYPES = %w[BookSection QuizQuestion].freeze
+
+  def index
+    @q_user_id    = params[:user_id]
+    @q_type       = params[:target_type]
+    @q_role       = params[:role]
+
+    @perms = EditorPermission.includes(:user).order(created_at: :desc)
+    @perms = @perms.where(user_id: @q_user_id) if @q_user_id.present?
+    @perms = @perms.where(target_type: @q_type) if @q_type.present?
+    @perms = @perms.where(role: @q_role)       if @q_role.present?
+    @perms = @perms.page(params[:page])
+  end
+
+  def show; end
+  def new;  @perm = EditorPermission.new; end
+  def edit; end
+
+  def create
+    @perm = EditorPermission.new(perm_params)
+    if @perm.save
+      redirect_to admin_editor_permissions_path, notice: "編集権限を付与しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @perm.update(perm_params)
+      redirect_to admin_editor_permission_path(@perm), notice: "編集権限を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @perm.destroy
+    redirect_to admin_editor_permissions_path, notice: "編集権限を解除しました"
+  end
+
+  # ---------- 一括付与 ----------
+  def bulk_new
+    @perm = EditorPermission.new
+  end
+
+  def bulk_create
+    # :role は受け取らない（サーバ側で固定）
+    raw      = params.require(:editor_permission).permit(:user_id, :target_type)
+    user_id  = Integer(raw[:user_id])
+    type     = raw[:target_type].to_s
+
+    # type のホワイトリスト検証
+    unless TARGET_TYPES.include?(type)
+      raise ActionController::BadRequest, "invalid target_type"
+    end
+
+    # role はフォーム値を無視して固定（sub_editor のみ）
+    fixed_role = :sub_editor
+
+    raw_ids = params[:target_ids_text].to_s
+    ids     = raw_ids.scan(/\d+/).map(&:to_i).uniq
+
+    created = []
+    skipped = []
+
+    EditorPermission.transaction do
+      ids.each do |tid|
+        rec = EditorPermission.find_or_initialize_by(user_id: user_id, target_type: type, target_id: tid)
+        if rec.persisted?
+          skipped << tid
+        else
+          rec.role = fixed_role
+          rec.save!
+          created << tid
+        end
+      end
+    end
+
+    msg = []
+    msg << "作成: #{created.size}件(#{created.take(10).join(', ')}#{'…' if created.size > 10})" if created.any?
+    msg << "重複スキップ: #{skipped.size}件" if skipped.any?
+    redirect_to admin_editor_permissions_path, notice: msg.presence || "対象IDが指定されていません"
+  rescue ArgumentError
+    @perm = EditorPermission.new(user_id: raw[:user_id], target_type: type, role: fixed_role)
+    flash.now[:alert] = "作成に失敗しました: invalid id"
+    render :bulk_new, status: :unprocessable_entity
+  rescue ActiveRecord::RecordInvalid => e
+    @perm = EditorPermission.new(user_id: raw[:user_id], target_type: type, role: fixed_role)
+    flash.now[:alert] = "作成に失敗しました: #{e.message}"
+    render :bulk_new, status: :unprocessable_entity
+  end
+
+  # ---------- Ajax: ID → 人間向けラベル ----------
+  def describe_target
+    type = params[:target_type].to_s
+    id   = params[:target_id].to_s
+
+    label =
+      if TARGET_TYPES.include?(type)
+        case type
+        when "BookSection"
+          if (rec = BookSection.find_by(id: id))
+            book = rec.try(:book)&.title
+            sec  = rec.try(:heading) || rec.try(:title)
+            [ "BookSection##{id}", [ book, sec ].compact.join(" / ") ].reject(&:blank?).join(" — ")
+          end
+        when "QuizQuestion"
+          if (rec = QuizQuestion.find_by(id: id))
+            quiz = rec.try(:quiz)&.title
+            sect = rec.try(:quiz_section)&.heading
+            qpos = rec.try(:position)
+            [ "QuizQuestion##{id}", [ quiz, sect, ("Q#{qpos}" if qpos) ].compact.join(" / ") ].reject(&:blank?).join(" — ")
+          end
+        end
+      end
+
+    render json: { label: label.presence || "#{type}##{id}（見つかりません）" }
+  end
+
+  # ---------- Ajax: ユーザーのロール（admin/editor?） ----------
+  def user_status
+    u = User.find_by(id: params[:user_id])
+    if u
+      render json: {
+        ok: true,
+        admin:  u.admin?,
+        editor: u.editor?,
+        label:  (u.admin? ? "管理者" : (u.editor? ? "編集者" : nil))
+      }
+    else
+      render json: { ok: false }
+    end
+  end
+
+  private
+
+  def set_permission
+    @perm = EditorPermission.find(params[:id])
+  end
+
+  # Strong Parameters の“見た目”は保ちつつ、最終的に安全な固定値/型へ変換して返す
+  def perm_params
+    raw = params.require(:editor_permission).permit(:user_id, :target_type, :target_id)
+    type = raw[:target_type].to_s
+
+    # target_type はホワイトリストで厳格化
+    raise ActionController::BadRequest, "invalid target_type" unless TARGET_TYPES.include?(type)
+
+    {
+      user_id: Integer(raw[:user_id]),
+      target_type: type,
+      target_id: Integer(raw[:target_id]),
+      role: :sub_editor # ここで固定（フォーム値は無視）
+    }
+  rescue ArgumentError
+    # Integer() 失敗時など
+    raise ActionController::BadRequest, "invalid id"
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,3 +1,4 @@
+# app/controllers/admin/users_controller.rb
 class Admin::UsersController < Admin::BaseController
   layout "admin"
 
@@ -9,7 +10,8 @@ class Admin::UsersController < Admin::BaseController
 
     @users = User.search(@q)
                  .yield_self { |u| @filter == "editors" ? u.editors : u }
-                 .yield_self { |u| @filter == "banned" ? u.banned : u }
+                 .yield_self { |u| @filter == "banned"  ? u.banned  : u }
+                 .includes(:editor_permissions)
                  .order(created_at: :desc)
                  .page(params[:page]).per(50)
   end

--- a/app/controllers/admin/versions_controller.rb
+++ b/app/controllers/admin/versions_controller.rb
@@ -1,0 +1,107 @@
+# app/controllers/admin/versions_controller.rb
+class Admin::VersionsController < Admin::BaseController
+  layout "admin"
+
+  ALLOWED_ITEM_TYPES = %w[BookSection QuizQuestion].freeze
+
+  def index
+    versions = PaperTrail::Version.order(created_at: :desc)
+    versions = versions.where(item_type: params[:item_type]) if params[:item_type].present?
+    versions = versions.where(item_id:   params[:item_id])   if params[:item_id].present?
+    @versions = versions.page(params[:page])
+  end
+
+  def show
+    @version = PaperTrail::Version.find(params[:id])
+    @record  = safe_reify(@version) # create のときは nil
+  end
+
+  def revert
+    version = PaperTrail::Version.find(params[:id])
+    record  = safe_reify(version)
+
+    if record.nil?
+      # create の巻き戻し = 現在存在するレコードを削除
+      model_klass = safe_model_for_item_type(version.item_type)
+      if model_klass
+        model_klass.find_by(id: version.item_id)&.destroy!
+      end
+      redirect_to admin_versions_path(item_type: version.item_type, item_id: version.item_id),
+                  notice: "この作成を取り消しました（削除）"
+      return
+    end
+
+    record.save!
+    redirect_to admin_versions_path(item_type: version.item_type, item_id: version.item_id),
+                notice: "この版にロールバックしました"
+  end
+
+  # ＝＝＝＝ 単体削除 ＝＝＝＝
+  def destroy
+    v = PaperTrail::Version.find(params[:id])
+    v.destroy
+    redirect_back fallback_location: admin_versions_path, notice: "版を削除しました"
+  end
+
+  # ＝＝＝＝ 一括削除 ＝＝＝＝
+  def bulk_destroy
+    ids = Array(params[:version_ids]).map(&:to_i).uniq
+    if ids.empty?
+      redirect_back fallback_location: admin_versions_path, alert: "削除対象が選択されていません"
+      return
+    end
+    PaperTrail::Version.where(id: ids).in_batches { |rel| rel.delete_all }
+    redirect_back fallback_location: admin_versions_path, notice: "#{ids.size}件の版を削除しました"
+  end
+
+  private
+
+  # YAML/JSON どちらでも安全に reify する
+  def safe_reify(version)
+    # まず JSON (現行設定) でトライ
+    version.reify
+  rescue JSON::ParserError
+    # YAML の可能性が高い → YAML serializer で再トライ
+    PaperTrail.serializer = PaperTrail::Serializers::YAML
+    begin
+      version.reify
+    ensure
+      # 終わったら必ず JSON に戻す
+      PaperTrail.serializer = PaperTrail::Serializers::JSON
+    end
+  rescue Psych::DisallowedClass
+    permit_yaml_classes!
+    retry
+  end
+
+  # 一時的に PaperTrail の serializer を YAML にしてブロックを実行
+  def with_yaml_serializer
+    PaperTrail.request do |req|
+      prev = req.serializer
+      req.serializer = PaperTrail::Serializers::YAML
+      begin
+        return yield
+      ensure
+        req.serializer = prev
+      end
+    end
+  end
+
+  # YAML 安全読み込みの許可クラスを追加
+  def permit_yaml_classes!
+    permitted = [
+      Time, Date, Symbol,
+      ActiveSupport::TimeZone,
+      ActiveSupport::TimeWithZone
+    ]
+    if ActiveRecord.respond_to?(:yaml_column_permitted_classes)
+      ActiveRecord.yaml_column_permitted_classes |= permitted
+    end
+  end
+
+  def safe_model_for_item_type(item_type)
+    type = item_type.to_s
+    return nil unless ALLOWED_ITEM_TYPES.include?(type)
+    type.safe_constantize
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
   helper_method :current_user, :logged_in?
 
+  before_action :set_paper_trail_whodunnit
+
   rescue_from ActiveRecord::RecordNotFound do
     respond_to do |f|
       # HTMLアクセス時 → public/404.html を返す

--- a/app/controllers/book_sections_controller.rb
+++ b/app/controllers/book_sections_controller.rb
@@ -1,24 +1,46 @@
+# app/controllers/book_sections_controller.rb
 class BookSectionsController < ApplicationController
+  include EditPermission
+  include ActionView::Helpers::SanitizeHelper
   before_action :set_book
+  before_action :set_section, only: %i[show edit update]
   helper_method :logged_in?
 
   def show
-    # ネストURLなので同一Book内に限定して安全に検索
-    @section = @book.book_sections.find(params[:id])
-
-    # ★未ログインかつ FREE でなければログインへ
-    unless @section.is_free? || logged_in?
-      # 可能なら戻り先を保存（アプリに store_location があれば）
-      if respond_to?(:store_location, true)
-        store_location(book_section_path(@book, @section))
-      end
-      redirect_to(new_session_path, alert: "このページを表示するにはログインが必要です")
+    unless @section.is_free || logged_in?
+      store_location(book_section_path(@book, @section)) if respond_to?(:store_location, true)
+      redirect_to new_session_path, alert: "このページを表示するにはログインが必要です"
       return
     end
-
-    # 表示継続（前後リンク用）
     @prev = @section.previous
     @next = @section.next
+  end
+
+  def edit
+    nil unless require_edit_permission!(@section)
+  end
+
+  def update
+    return unless require_edit_permission!(@section)
+
+    attrs = section_params.slice(*@section.editable_attributes)
+    attrs[:content] = sanitize_content(attrs[:content])
+    attrs[:lock_version] = section_params[:lock_version]
+
+    begin
+      @section.with_lock do
+        @section.assign_attributes(attrs)
+        if @section.save
+          attach_images_from_content!(@section, prune: true)
+          redirect_to book_section_path(@book, @section), notice: "更新しました"
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    rescue ActiveRecord::StaleObjectError
+      flash.now[:alert] = "他の編集と競合しました。最新の内容を確認して再度保存してください。"
+      render :edit, status: :conflict
+    end
   end
 
   private
@@ -27,7 +49,49 @@ class BookSectionsController < ApplicationController
     @book = Book.find(params[:book_id])
   end
 
-  # アプリに既に同等のヘルパがあるなら不要。無ければ簡易版を用意。
+  def set_section
+    @section = @book.book_sections.find(params[:id])
+  end
+
+  def section_params
+    params.require(:book_section).permit(:content, :lock_version)
+  end
+
+  # ===== 同じロジックをこちらにも持たせる（簡易版） =====
+  SIGNED_ID_IMG_SRC =
+    %r{/rails/active_storage/(?:blobs|representations)(?:/redirect)?/([A-Za-z0-9_\-=]+)}.freeze
+
+  def attach_images_from_content!(section, prune: false)
+    return if section.content.blank?
+
+    signed_ids = section.content.scan(SIGNED_ID_IMG_SRC).flatten.uniq
+    return if signed_ids.empty?
+
+    blobs = signed_ids.filter_map do |sid|
+      begin
+        ActiveStorage::Blob.find_signed(sid)
+      rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
+        nil
+      end
+    end
+
+    current_blob_ids = section.images.attachments.map(&:blob_id)
+    blobs.reject { |b| current_blob_ids.include?(b.id) }.each { |blob| section.images.attach(blob) }
+
+    if prune
+      keep = blobs.map(&:id)
+      section.images.attachments.reject { |att| keep.include?(att.blob_id) }.each(&:purge)
+    end
+  end
+
+  def sanitize_content(html)
+    sanitize(
+      html,
+      tags: %w[p h1 h2 h3 h4 h5 h6 b i u strong em a ul ol li pre code blockquote br span div img hr],
+      attributes: %w[href class target rel src alt style]
+    )
+  end
+
   def logged_in?
     !!current_user
   end

--- a/app/controllers/concerns/edit_permission.rb
+++ b/app/controllers/concerns/edit_permission.rb
@@ -1,0 +1,19 @@
+# app/controllers/concerns/edit_permission.rb
+module EditPermission
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :can_edit?
+  end
+
+  def can_edit?(record)
+    return false unless current_user
+    current_user.admin? || current_user.can_edit?(record)
+  end
+
+  def require_edit_permission!(record)
+    return true if can_edit?(record)
+    redirect_back fallback_location: root_path, alert: "編集権限がありません"
+    false
+  end
+end

--- a/app/helpers/admin/editor_permissions_helper.rb
+++ b/app/helpers/admin/editor_permissions_helper.rb
@@ -1,0 +1,34 @@
+# app/helpers/admin/editor_permissions_helper.rb
+module Admin::EditorPermissionsHelper
+  def role_badge(role)
+    %(<span class="px-2 py-0.5 rounded text-xs bg-indigo-100 text-indigo-700">#{h role}</span>).html_safe
+  end
+
+  def type_badge(type)
+    %(<span class="px-2 py-0.5 rounded text-xs bg-slate-100 text-slate-700">#{h type}</span>).html_safe
+  end
+
+  def target_preview_text(type, id)
+    return "" if type.blank? || id.blank?
+    begin
+      label = case type
+      when "BookSection"
+        if (rec = BookSection.find_by(id: id))
+          book = rec.try(:book)&.title
+          sec  = rec.try(:heading) || rec.try(:title)
+          [ "BookSection##{id}", [ book, sec ].compact.join(" / ") ].reject(&:blank?).join(" — ")
+        end
+      when "QuizQuestion"
+        if (rec = QuizQuestion.find_by(id: id))
+          quiz = rec.try(:quiz)&.title
+          sect = rec.try(:quiz_section)&.heading
+          qpos = rec.try(:position)
+          [ "QuizQuestion##{id}", [ quiz, sect, ("Q#{qpos}" if qpos) ].compact.join(" / ") ].reject(&:blank?).join(" — ")
+        end
+      end
+      label.presence || "#{type}##{id}（見つかりません）"
+    rescue
+      "#{type}##{id}"
+    end
+  end
+end

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,2 +1,15 @@
+# app/helpers/admin/users_helper.rb
 module Admin::UsersHelper
+  def role_badge_for(user)
+    role = user.effective_role
+    label, cls =
+      case role
+      when :admin      then [ "管理者",  "bg-amber-50 text-amber-700 ring-amber-200" ]
+      when :editor     then [ "編集者",  "bg-indigo-50 text-indigo-700 ring-indigo-200" ]
+      when :sub_editor then [ "sub_editor", "bg-sky-50 text-sky-700 ring-sky-200" ]
+      else                  [ "一般",    "bg-slate-50 text-slate-600 ring-slate-200" ]
+      end
+
+    %(<span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ring-inset #{cls}">#{h label}</span>).html_safe
+  end
 end

--- a/app/helpers/admin/versions_helper.rb
+++ b/app/helpers/admin/versions_helper.rb
@@ -1,0 +1,31 @@
+# app/helpers/admin/versions_helper.rb
+module Admin::VersionsHelper
+  # HTMLを人が読みやすいプレーンテキストへ
+  # - <br>       => 改行
+  # - </p> </li> => 改行（段落/箇条書きの区切り）
+  # - <li>       => 先頭に中黒（・）
+  # その後 strip_tags で安全にタグ除去
+  def textify_html(html)
+    s = html.to_s.dup
+    s.gsub!(/<br\s*\/?>/i, "\n")
+    s.gsub!(/<\/p\s*>/i, "\n\n")
+    s.gsub!(/<\/li\s*>/i, "\n")
+    s.gsub!(/<li[^>]*>/i, "・")
+    s = strip_tags(s)
+    s.gsub(/\n{3,}/, "\n\n").strip
+  end
+
+  # とりあえずの行単位の簡易差分
+  # （厳密なLCSではないが軽量で、どこが増減したかは掴める）
+  def simple_line_diff(before_html, after_html)
+    before_lines = textify_html(before_html).split(/\r?\n/)
+    after_lines  = textify_html(after_html).split(/\r?\n/)
+
+    {
+      added:   after_lines - before_lines,
+      removed: before_lines - after_lines,
+      before_lines:,
+      after_lines:
+    }
+  end
+end

--- a/app/jobs/versions_cleanup_job.rb
+++ b/app/jobs/versions_cleanup_job.rb
@@ -1,0 +1,38 @@
+# app/jobs/versions_cleanup_job.rb
+class VersionsCleanupJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    keep_n   = Rails.configuration.x.versions.keep_per_item
+    keep_day = Rails.configuration.x.versions.keep_days
+    batch    = Rails.configuration.x.versions.cleanup_batch
+
+    cutoff = keep_day.positive? ? keep_day.days.ago : nil
+
+    # ① 期限切れ（作成日時が古い）を削除
+    if cutoff
+      PaperTrail::Version.where("created_at < ?", cutoff).in_batches(of: batch) { |rel| rel.delete_all }
+    end
+
+    # ② 各 item ごとに最新 keep_n を残し、それ以外を削除
+    return if keep_n <= 0
+
+    # item_type, item_id の組でグルーピングして古いものを削る
+    PaperTrail::Version.
+      select(:item_type, :item_id).
+      distinct.
+      in_batches(of: 500) do |pairs|
+        pairs.each do |pair|
+          scope = PaperTrail::Version.
+                    where(item_type: pair.item_type, item_id: pair.item_id).
+                    order(created_at: :desc, id: :desc)
+          ids_to_keep = scope.limit(keep_n).pluck(:id)
+          next if ids_to_keep.empty?
+          PaperTrail::Version.
+            where(item_type: pair.item_type, item_id: pair.item_id).
+            where.not(id: ids_to_keep).
+            in_batches(of: batch) { |rel| rel.delete_all }
+        end
+      end
+  end
+end

--- a/app/models/book_section.rb
+++ b/app/models/book_section.rb
@@ -1,5 +1,6 @@
 # app/models/book_section.rb
 class BookSection < ApplicationRecord
+  has_paper_trail
   belongs_to :book, counter_cache: true, touch: true
   has_many_attached :images
 
@@ -24,5 +25,12 @@ class BookSection < ApplicationRecord
 
   def next
     book.book_sections.where("position > ?", position).order(position: :asc).first
+  end
+
+  # =======================
+  # 編集権限チェック
+  # =======================
+  def editable_attributes
+    %i[content] # 画像は本文内のsigned_idをattachする既存仕組みで取り込み
   end
 end

--- a/app/models/editor_permission.rb
+++ b/app/models/editor_permission.rb
@@ -1,0 +1,45 @@
+# app/models/editor_permission.rb
+class EditorPermission < ApplicationRecord
+  belongs_to :user
+
+  # このモデルで許可する対象タイプ（ホワイトリスト）
+  VALID_TARGET_TYPES = %w[BookSection QuizQuestion].freeze
+
+  # sub_editor のみ（サイト全体編集は users.editor を使う）
+  enum :role, { sub_editor: 0 }, prefix: true
+
+  validates :target_type, presence: true, inclusion: { in: VALID_TARGET_TYPES }
+  validates :target_id,   presence: true, numericality: { only_integer: true }
+
+  # ---- 表示用ヘルパ（モデル側でも呼べるように） ----
+  def target_record
+    return nil if target_type.blank? || target_id.blank?
+    return nil unless VALID_TARGET_TYPES.include?(target_type)
+
+    # ここは constantize の前にホワイトリストで必ず絞り込む
+    target_type.constantize.find_by(id: target_id)
+  rescue NameError
+    nil
+  end
+
+  def target_human_label
+    rec  = target_record
+    base = "#{target_type}##{target_id}"
+    return base unless rec
+
+    case rec
+    when defined?(BookSection) && BookSection
+      book_title = rec.respond_to?(:book) ? rec.book&.title : nil
+      sec_title  = rec.try(:heading) || rec.try(:title)
+      [ base, [ book_title, sec_title ].compact.join(" / ") ].reject(&:blank?).join(" — ")
+    when defined?(QuizQuestion) && QuizQuestion
+      quiz_title = rec.try(:quiz)&.title
+      section_h  = rec.try(:quiz_section)&.heading
+      qpos       = rec.try(:position)
+      tail = [ quiz_title, section_h, ("Q#{qpos}" if qpos) ].compact.join(" / ")
+      [ base, tail ].reject(&:blank?).join(" — ")
+    else
+      base
+    end
+  end
+end

--- a/app/models/quiz_question.rb
+++ b/app/models/quiz_question.rb
@@ -1,5 +1,6 @@
 # app/models/quiz_question.rb
 class QuizQuestion < ApplicationRecord
+  has_paper_trail
   belongs_to :quiz
   belongs_to :quiz_section
 
@@ -13,4 +14,9 @@ class QuizQuestion < ApplicationRecord
   validates :correct_choice, presence: true, inclusion: { in: 1..4 }
   validates :position, presence: true,
                        numericality: { only_integer: true, greater_than: 0 }
+
+  # 編集権限チェック
+  def editable_attributes
+    %i[question choice1 choice2 choice3 choice4 correct_choice explanation]
+  end
 end

--- a/app/views/admin/editor_permissions/_form.html.erb
+++ b/app/views/admin/editor_permissions/_form.html.erb
@@ -1,0 +1,90 @@
+<!-- app/views/admin/editor_permissions/_form.html.erb -->
+<%= form_with model: @perm, url: @perm.new_record? ? admin_editor_permissions_path : admin_editor_permission_path(@perm),
+              method: @perm.new_record? ? :post : :patch, local: true, class: "space-y-5" do |f| %>
+  <div>
+    <%= f.label :user_id, "User", class: "block text-sm text-slate-600 mb-1" %>
+    <%= f.collection_select :user_id, User.order(:name), :id, :name, {}, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2", id: "editor_permission_user_id" %>
+    <div id="user_role_notice" class="mt-2 text-sm"></div>
+  </div>
+
+  <!-- 必要に応じて隠す -->
+  <div id="perm_fields_block">
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-4">
+      <div class="lg:col-span-4">
+        <%= f.label :target_type, "Target type", class: "block text-sm text-slate-600 mb-1" %>
+        <%= f.select :target_type, [["BookSection","BookSection"],["QuizQuestion","QuizQuestion"]],
+                    {}, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2", id: "target_type" %>
+      </div>
+      <div class="lg:col-span-4">
+        <%= f.label :target_id, "Target ID", class: "block text-sm text-slate-600 mb-1" %>
+        <%= f.number_field :target_id, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2", id: "target_id" %>
+      </div>
+      <div class="lg:col-span-4">
+        <%= f.label :role, "Role", class: "block text-sm text-slate-600 mb-1" %>
+        <%= f.select :role, EditorPermission.roles.keys.map { |r| [r, r] }, {}, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+      </div>
+    </div>
+
+    <div class="rounded border bg-slate-50 p-3 text-sm mt-2" id="target_preview">Target プレビュー: -</div>
+  </div>
+
+  <div class="flex gap-2">
+    <%= f.submit @perm.new_record? ? "付与する" : "更新する", class: "px-4 py-2 rounded bg-slate-900 text-white" %>
+    <%= link_to "一覧に戻る", admin_editor_permissions_path, class: "px-4 py-2 rounded ring-1 ring-slate-300 bg-white" %>
+  </div>
+<% end %>
+
+<script>
+  (function(){
+    const typeEl  = document.getElementById("target_type");
+    const idEl    = document.getElementById("target_id");
+    const prevEl  = document.getElementById("target_preview");
+    const userEl  = document.getElementById("editor_permission_user_id");
+    const blockEl = document.getElementById("perm_fields_block");
+    const noteEl  = document.getElementById("user_role_notice");
+
+    async function refreshPreview() {
+      const t = typeEl?.value, i = idEl?.value;
+      if(!t || !i){ if(prevEl){ prevEl.textContent = "Target プレビュー: -"; } return; }
+      try {
+        const res = await fetch("<%= describe_target_admin_editor_permissions_path %>?target_type=" + encodeURIComponent(t) + "&target_id=" + encodeURIComponent(i));
+        const json = await res.json();
+        if(prevEl){ prevEl.textContent = "Target プレビュー: " + json.label; }
+      } catch(e) {
+        if(prevEl){ prevEl.textContent = "Target プレビュー: 取得失敗"; }
+      }
+    }
+
+    async function refreshUserRole() {
+      const uid = userEl?.value;
+      if(!uid){ showBlock(true); noteEl.textContent = ""; return; }
+      try {
+        const res  = await fetch("<%= user_status_admin_editor_permissions_path %>?user_id=" + encodeURIComponent(uid));
+        const json = await res.json();
+        if(json.ok && (json.admin || json.editor)) {
+          const label = json.admin ? "管理者" : "編集者";
+          noteEl.innerHTML = `<span class="text-amber-700 bg-amber-50 ring-1 ring-amber-200 rounded px-2 py-1">このユーザーは${label}です。</span>`;
+          showBlock(false); // 隠す
+        } else {
+          noteEl.textContent = "";
+          showBlock(true);  // 表示
+        }
+      } catch(e) {
+        noteEl.textContent = "";
+        showBlock(true);
+      }
+    }
+
+    function showBlock(show){
+      if(!blockEl) return;
+      blockEl.style.display = show ? "" : "none";
+    }
+
+    typeEl?.addEventListener("change", refreshPreview);
+    idEl?.addEventListener("input", refreshPreview);
+    userEl?.addEventListener("change", ()=>{ refreshUserRole(); setTimeout(refreshPreview, 0); });
+
+    document.addEventListener("turbo:load", ()=>{ refreshUserRole(); refreshPreview(); });
+    document.addEventListener("DOMContentLoaded", ()=>{ refreshUserRole(); refreshPreview(); });
+  })();
+</script>

--- a/app/views/admin/editor_permissions/bulk_new.html.erb
+++ b/app/views/admin/editor_permissions/bulk_new.html.erb
@@ -1,0 +1,68 @@
+<!-- app/views/admin/editor_permissions/bulk_new.html.erb -->
+<h1 class="text-2xl font-bold mb-6">編集権限を一括付与</h1>
+
+<%= form_with url: bulk_create_admin_editor_permissions_path, method: :post, local: true, class: "space-y-5" do |f| %>
+  <div>
+    <label class="block text-sm text-slate-600 mb-1">User</label>
+    <select name="editor_permission[user_id]" class="w-full rounded ring-1 ring-slate-300 px-3 py-2">
+      <% User.order(:name).each do |u| %>
+        <option value="<%= u.id %>"><%= u.name %></option>
+      <% end %>
+    </select>
+  </div>
+
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+    <div>
+      <label class="block text-sm text-slate-600 mb-1">Target type</label>
+      <select name="editor_permission[target_type]" id="bulk_type" class="w-full rounded ring-1 ring-slate-300 px-3 py-2">
+        <option value="BookSection">BookSection</option>
+        <option value="QuizQuestion">QuizQuestion</option>
+      </select>
+    </div>
+    <div>
+      <label class="block text-sm text-slate-600 mb-1">Role</label>
+      <select name="editor_permission[role]" class="w-full rounded ring-1 ring-slate-300 px-3 py-2">
+        <% EditorPermission.roles.keys.each do |r| %>
+          <option value="<%= r %>"><%= r %></option>
+        <% end %>
+      </select>
+    </div>
+  </div>
+
+  <div>
+    <label class="block text-sm text-slate-600 mb-1">Target IDs（カンマ/空白/改行区切り）</label>
+    <textarea id="bulk_ids" name="target_ids_text" rows="6" class="w-full rounded ring-1 ring-slate-300 px-3 py-2" placeholder="例） 1,2,3  または  1 2 3  または  改行で 1行1 ID"></textarea>
+    <div id="bulk_preview" class="mt-2 text-sm text-slate-600"></div>
+  </div>
+
+  <div class="flex gap-2">
+    <button class="px-4 py-2 rounded bg-slate-900 text-white">一括付与する</button>
+    <%= link_to "一覧に戻る", admin_editor_permissions_path, class: "px-4 py-2 rounded ring-1 ring-slate-300 bg-white" %>
+  </div>
+<% end %>
+
+<script>
+  (function(){
+    const typeEl = document.getElementById("bulk_type");
+    const idsEl  = document.getElementById("bulk_ids");
+    const outEl  = document.getElementById("bulk_preview");
+
+    async function refresh(){
+      const t = typeEl.value;
+      const ids = (idsEl.value.match(/\d+/g) || []).slice(0, 20); // プレビューは最大20件
+      if(ids.length === 0){ outEl.textContent = "プレビュー: 0 件"; return; }
+      outEl.textContent = "プレビュー取得中…";
+      const labels = await Promise.all(ids.map(async (id)=>{
+        try{
+          const res = await fetch(`<%= describe_target_admin_editor_permissions_path %>?target_type=${encodeURIComponent(t)}&target_id=${encodeURIComponent(id)}`);
+          const j = await res.json(); return j.label;
+        }catch(e){ return `${t}#${id}`; }
+      }));
+      outEl.innerHTML = `プレビュー: ${ids.length}件<br>` + labels.map(l=>`・${l}`).join("<br>");
+    }
+    typeEl && typeEl.addEventListener("change", refresh);
+    idsEl  && idsEl.addEventListener("input", refresh);
+    document.addEventListener("turbo:load", refresh);
+    document.addEventListener("DOMContentLoaded", refresh);
+  })();
+</script>

--- a/app/views/admin/editor_permissions/edit.html.erb
+++ b/app/views/admin/editor_permissions/edit.html.erb
@@ -1,0 +1,3 @@
+<!-- app/views/admin/editor_permissions/edit.html.erb -->
+<h1 class="text-2xl font-bold mb-6">編集権限を編集</h1>
+<%= render "form" %>

--- a/app/views/admin/editor_permissions/index.html.erb
+++ b/app/views/admin/editor_permissions/index.html.erb
@@ -1,0 +1,82 @@
+<!-- app/views/admin/editor_permissions/index.html.erb -->
+<h1 class="text-2xl font-bold mb-6">Editor Permissions</h1>
+
+<div class="flex flex-wrap gap-3 mb-4">
+  <%= link_to "＋ 新規付与", new_admin_editor_permission_path, class: "px-3 py-2 rounded bg-slate-900 text-white" %>
+  <%= link_to "⇅ 一括付与", bulk_new_admin_editor_permissions_path, class: "px-3 py-2 rounded ring-1 ring-slate-300 bg-white" %>
+</div>
+
+<%= form_with url: admin_editor_permissions_path, method: :get, local: true, class: "grid grid-cols-1 md:grid-cols-12 gap-3 items-end mb-5" do %>
+  <div class="md:col-span-5">
+    <label class="block text-sm text-slate-600 mb-1">User</label>
+    <select name="user_id" class="w-full rounded ring-1 ring-slate-300 px-3 py-2">
+      <option value="">(すべて)</option>
+      <% User.order(:name).each do |u| %>
+        <option value="<%= u.id %>" <%= "selected" if params[:user_id].to_s == u.id.to_s %>><%= u.name %></option>
+      <% end %>
+    </select>
+  </div>
+  <div class="md:col-span-3">
+    <label class="block text-sm text-slate-600 mb-1">Target type</label>
+    <select name="target_type" class="w-full rounded ring-1 ring-slate-300 px-3 py-2">
+      <option value="">(すべて)</option>
+      <% ["BookSection","QuizQuestion"].each do |t| %>
+        <option value="<%= t %>" <%= "selected" if params[:target_type] == t %>><%= t %></option>
+      <% end %>
+    </select>
+  </div>
+  <div class="md:col-span-2">
+    <label class="block text-sm text-slate-600 mb-1">Role</label>
+    <select name="role" class="w-full rounded ring-1 ring-slate-300 px-3 py-2">
+      <option value="">(すべて)</option>
+      <% EditorPermission.roles.keys.each do |r| %>
+        <option value="<%= r %>" <%= "selected" if params[:role] == r %>><%= r %></option>
+      <% end %>
+    </select>
+  </div>
+  <div class="md:col-span-2">
+    <button class="w-full rounded bg-slate-900 text-white px-3 py-2">絞り込み</button>
+  </div>
+  <div class="md:col-span-0">
+    <%= link_to "リセット", admin_editor_permissions_path,
+        class: "rounded ring-1 ring-slate-300 px-4 py-2 bg-white" %>
+  </div>
+<% end %>
+
+<div class="overflow-x-auto rounded border bg-white">
+  <table class="min-w-full text-sm">
+    <thead class="bg-slate-50 text-slate-600">
+      <tr>
+        <th class="p-2 text-left w-48">User</th>
+        <th class="p-2 text-left">Target</th>
+        <th class="p-2 text-left w-28">Role</th>
+        <th class="p-2 text-left w-48">作成日時</th>
+        <th class="p-2 w-40"></th>
+      </tr>
+    </thead>
+    <tbody class="divide-y">
+      <% @perms.each do |p| %>
+        <tr class="hover:bg-slate-50">
+          <td class="p-2 whitespace-nowrap"><%= p.user.name %></td>
+          <td class="p-2">
+            <%= type_badge(p.target_type) %>
+            <span class="ml-2"><%= p.target_human_label %></span>
+          </td>
+          <td class="p-2"><%= role_badge(p.role) %></td>
+          <td class="p-2 whitespace-nowrap"><%= l p.created_at, format: :long %></td>
+          <td class="p-2 text-right whitespace-nowrap">
+            <%= link_to "詳細", admin_editor_permission_path(p),
+                  class: "inline-block rounded px-3 py-1 bg-slate-900 text-white text-xs" %>
+            <%= link_to "編集", edit_admin_editor_permission_path(p),
+                  class: "inline-block rounded px-3 py-1 ring-1 ring-slate-300 bg-white text-xs" %>
+            <%= link_to "削除", admin_editor_permission_path(p),
+                  data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
+                  class: "inline-block rounded px-3 py-1 text-rose-600 text-xs" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<div class="mt-4"><%= paginate @perms if respond_to?(:paginate) %></div>

--- a/app/views/admin/editor_permissions/new.html.erb
+++ b/app/views/admin/editor_permissions/new.html.erb
@@ -1,0 +1,3 @@
+<!-- app/views/admin/editor_permissions/new.html.erb -->
+<h1 class="text-2xl font-bold mb-6">編集権限を付与</h1>
+<%= render "form" %>

--- a/app/views/admin/editor_permissions/show.html.erb
+++ b/app/views/admin/editor_permissions/show.html.erb
@@ -1,0 +1,30 @@
+<!-- app/views/admin/editor_permissions/show.html.erb -->
+<h1 class="text-2xl font-bold mb-6">権限の詳細</h1>
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+  <div class="rounded border bg-white">
+    <div class="px-4 py-3 border-b font-semibold">概要</div>
+    <div class="px-4 py-3 text-sm grid grid-cols-3 gap-2 items-center">
+      <div class="text-slate-500">User</div><div class="col-span-2"><%= @perm.user.name %></div>
+      <div class="text-slate-500">Target</div>
+      <div class="col-span-2">
+        <%= type_badge(@perm.target_type) %>
+        <span class="ml-2"><%= @perm.target_human_label %></span>
+      </div>
+      <div class="text-slate-500">Role</div><div class="col-span-2"><%= role_badge(@perm.role) %></div>
+      <div class="text-slate-500">作成</div><div class="col-span-2"><%= l @perm.created_at, format: :long %></div>
+      <div class="text-slate-500">更新</div><div class="col-span-2"><%= l @perm.updated_at, format: :long %></div>
+    </div>
+  </div>
+
+  <div class="rounded border bg-white">
+    <div class="px-4 py-3 border-b font-semibold">操作</div>
+    <div class="px-4 py-3 flex flex-wrap gap-3">
+      <%= link_to "編集", edit_admin_editor_permission_path(@perm), class: "rounded px-4 py-2 bg-slate-900 text-white" %>
+      <%= link_to "削除", admin_editor_permission_path(@perm),
+            data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
+            class: "rounded px-4 py-2 ring-1 ring-slate-300 bg-white text-rose-600" %>
+      <%= link_to "一覧へ戻る", admin_editor_permissions_path, class: "rounded px-4 py-2 ring-1 ring-slate-300 bg-white" %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/quiz_questions/update.html.erb
+++ b/app/views/admin/quiz_questions/update.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::QuizQuestions#update</h1>
+<p>Find me in app/views/admin/quiz_questions/update.html.erb</p>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -28,7 +28,7 @@
       <tr>
         <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">名前</th>
         <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">メール</th>
-        <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">編集者</th>
+        <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">権限</th>
         <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">状態</th>
         <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">操作</th>
       </tr>
@@ -39,22 +39,8 @@
           <td class="px-4 py-2 font-medium text-slate-900"><%= u.name %></td>
           <td class="px-4 py-2 text-slate-700"><%= u.email %></td>
 
-          <!-- 編集者バッジ -->
-          <td class="px-4 py-2">
-            <% if u.admin? %>
-              <span class="inline-flex items-center rounded-full bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-200">
-                管理者
-              </span>
-            <% elsif u.editor? %>
-              <span class="inline-flex items-center rounded-full bg-indigo-50 px-2.5 py-0.5 text-xs font-medium text-indigo-700 ring-1 ring-inset ring-indigo-200">
-                編集者
-              </span>
-            <% else %>
-              <span class="inline-flex items-center rounded-full bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-600 ring-1 ring-inset ring-slate-200">
-                一般
-              </span>
-            <% end %>
-          </td>
+          <!-- 権限バッジ（admin > editor > sub_editor > 一般） -->
+          <td class="px-4 py-2"><%= role_badge_for(u) %></td>
 
           <!-- 凍結/有効バッジ -->
           <td class="px-4 py-2">
@@ -74,7 +60,6 @@
                       method: :patch,
                       class: "inline-flex items-center rounded-md bg-white px-3 py-1.5 text-xs font-medium text-slate-700 ring-1 ring-slate-300 hover:bg-slate-50" %>
 
-                <%#-- 凍結ボタンの表示ラベルと色を先に決める --%>
                 <% ban_label = u.banned? ? "解除" : "凍結" %>
                 <% ban_color = u.banned? ? "bg-emerald-600 hover:bg-emerald-700 ring-emerald-600"
                                          : "bg-rose-600 hover:bg-rose-700 ring-rose-600" %>

--- a/app/views/admin/versions/_value_cell.html.erb
+++ b/app/views/admin/versions/_value_cell.html.erb
@@ -1,0 +1,16 @@
+<%# 値の見せ方をユースケース別に切替 %>
+<% case v %>
+<% when Time, Date, ActiveSupport::TimeWithZone %>
+  <%= l v, format: :long %>
+<% when TrueClass, FalseClass, Integer, Float %>
+  <%= v %>
+<% when NilClass %>
+  <span class="text-slate-400">nil</span>
+<% else %>
+  <% str = v.to_s %>
+  <% if str.strip.start_with?("<") && str.include?("</") %>
+    <%= simple_format(h(strip_tags(str))) %>
+  <% else %>
+    <pre class="whitespace-pre-wrap"><%= str %></pre>
+  <% end %>
+<% end %>

--- a/app/views/admin/versions/index.html.erb
+++ b/app/views/admin/versions/index.html.erb
@@ -1,0 +1,92 @@
+<!-- app/views/admin/versions/index.html.erb -->
+<h1 class="text-2xl font-bold mb-6">変更履歴</h1>
+
+<%= form_with url: admin_versions_path, method: :get, local: true, class: "grid grid-cols-1 md:grid-cols-12 gap-3 items-end mb-5" do %>
+  <div class="md:col-span-5">
+    <label class="block text-sm text-slate-600 mb-1">対象モデル</label>
+    <input type="text" name="item_type" value="<%= params[:item_type] %>"
+           placeholder="例: BookSection / QuizQuestion"
+           class="w-full rounded ring-1 ring-slate-300 px-3 py-2">
+  </div>
+  <div class="md:col-span-3">
+    <label class="block text-sm text-slate-600 mb-1">対象ID</label>
+    <input type="text" name="item_id" value="<%= params[:item_id] %>"
+           placeholder="ID"
+           class="w-full rounded ring-1 ring-slate-300 px-3 py-2">
+  </div>
+  <div class="md:col-span-4 flex gap-2">
+    <button type="submit"
+            class="flex-1 rounded bg-slate-900 text-white px-5 py-2 text-center whitespace-nowrap">
+      絞り込み
+    </button>
+
+    <%= link_to "リセット", admin_versions_path,
+          class: "flex-1 rounded ring-1 ring-slate-300 px-5 py-2 text-center bg-white whitespace-nowrap" %>
+  </div>
+<% end %>
+
+<%= form_with url: bulk_destroy_admin_versions_path, method: :delete, data: { turbo_confirm: "選択した版を削除します。よろしいですか？" }, local: true do %>
+  <div class="mb-3 flex items-center gap-2">
+    <button class="px-3 py-2 rounded bg-rose-600 text-white text-sm">選択を削除</button>
+    <span class="text-xs text-slate-500">※ 削除は元に戻せません（レコード自体には影響しません）</span>
+  </div>
+
+  <div class="overflow-x-auto rounded border">
+    <table class="min-w-full text-sm">
+      <thead class="bg-slate-50 text-slate-600">
+        <tr>
+          <th class="p-2 w-10 text-center">
+            <input type="checkbox" id="check_all">
+          </th>
+          <th class="p-2 text-left w-48">日時</th>
+          <th class="p-2 text-left">タイプ</th>
+          <th class="p-2 text-right w-24">ID</th>
+          <th class="p-2 text-left w-28">イベント</th>
+          <th class="p-2 text-right w-24">ユーザー</th>
+          <th class="p-2 w-36"></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y">
+        <% @versions.each do |v| %>
+          <tr class="hover:bg-slate-50">
+            <td class="p-2 text-center">
+              <input type="checkbox" name="version_ids[]" value="<%= v.id %>" class="row-check">
+            </td>
+            <td class="p-2 whitespace-nowrap"><%= l v.created_at, format: :long %></td>
+            <td class="p-2 font-mono"><%= v.item_type %></td>
+            <td class="p-2 text-right"><%= v.item_id %></td>
+            <td class="p-2">
+              <% badge = case v.event
+                when "create" then "bg-emerald-100 text-emerald-700"
+                when "update" then "bg-amber-100 text-amber-700"
+                when "destroy" then "bg-rose-100 text-rose-700"
+                else "bg-slate-100 text-slate-700"
+              end %>
+              <span class="px-2 py-0.5 rounded text-xs <%= badge %>"><%= v.event %></span>
+            </td>
+            <td class="p-2 text-right"><%= v.whodunnit.presence || "-" %></td>
+            <td class="p-2 text-right whitespace-nowrap">
+              <%= link_to "詳細", admin_version_path(v),
+                    class: "inline-block rounded px-3 py-1 bg-slate-900 text-white text-xs" %>
+              <%= link_to "削除", admin_version_path(v),
+                    data: { turbo_method: :delete, turbo_confirm: "この版を削除します。よろしいですか？" },
+                    class: "inline-block rounded px-3 py-1 text-rose-600 text-xs" %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="mt-4"><%= paginate @versions if respond_to?(:paginate) %></div>
+<% end %>
+
+<script>
+  (function(){
+    const all = document.getElementById("check_all");
+    const rows = () => Array.from(document.querySelectorAll(".row-check"));
+    if(all){
+      all.addEventListener("change", ()=> rows().forEach(cb => cb.checked = all.checked));
+    }
+  })();
+</script>

--- a/app/views/admin/versions/show.html.erb
+++ b/app/views/admin/versions/show.html.erb
@@ -1,0 +1,146 @@
+<%# ===== Admin: Version Show ===== %>
+<h1 class="text-2xl font-bold mb-6">変更詳細</h1>
+
+<%# ===== メタ情報カード ===== %>
+<div class="grid grid-cols-1 md:grid-cols-5 gap-4 mb-8">
+  <div class="col-span-3 rounded border bg-white">
+    <div class="px-4 py-3 border-b font-semibold">対象</div>
+    <div class="px-4 py-3 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+      <div class="text-slate-500">Type</div><div class="font-mono"><%= @version.item_type %></div>
+      <div class="text-slate-500">ID</div><div><%= @version.item_id %></div>
+      <div class="text-slate-500">Event</div>
+      <div>
+        <% badge = case @version.event
+            when "create" then "bg-emerald-100 text-emerald-700"
+            when "update" then "bg-amber-100 text-amber-700"
+            when "destroy" then "bg-rose-100 text-rose-700"
+            else "bg-slate-100 text-slate-700"
+          end %>
+        <span class="px-2 py-0.5 rounded text-xs <%= badge %>"><%= @version.event %></span>
+      </div>
+      <div class="text-slate-500">Who</div><div><%= @version.whodunnit.presence || "-" %></div>
+      <div class="text-slate-500">When</div><div><%= l @version.created_at, format: :long %></div>
+    </div>
+  </div>
+
+  <div class="col-span-2 rounded border bg-white">
+    <div class="px-4 py-3 border-b font-semibold">アクション</div>
+    <div class="px-4 py-3 flex flex-wrap gap-3">
+      <%= button_to "この版にロールバック",
+            revert_admin_version_path(@version),
+            method: :post,
+            data: { turbo_confirm: "この版へ戻します。よろしいですか？" },
+            class: "rounded bg-slate-900 text-white px-4 py-2" %>
+
+      <%= link_to "一覧へ戻る",
+            admin_versions_path(item_type: @version.item_type, item_id: @version.item_id),
+            class: "rounded ring-1 ring-slate-300 px-4 py-2 bg-white" %>
+    </div>
+  </div>
+</div>
+
+<%# ===== 変更フィールド ===== %>
+<h2 class="text-xl font-semibold mb-4">変更フィールド</h2>
+
+<% if @version.changeset.present? %>
+  <%# 表示順序: updated_at, lock_version, content, その他 %>
+  <% ordered_keys = %w[updated_at lock_version content] + (@version.changeset.keys.map(&:to_s) - %w[updated_at lock_version content]) %>
+
+  <div class="space-y-6">
+    <% ordered_keys.each do |col| %>
+      <% before, after = @version.changeset[col] || [] %>
+
+      <% if col.to_s == "content" %>
+        <% text_before = textify_html(before) %>
+        <% text_after  = textify_html(after)  %>
+        <% diff = simple_line_diff(before, after) %>
+
+        <div class="rounded border overflow-hidden bg-white">
+          <div class="px-4 py-3 border-b flex items-center justify-between">
+            <div class="font-semibold">content（本文）</div>
+            <span class="text-xs text-slate-500">改行整形 & 簡易差分</span>
+          </div>
+
+          <%# 読みやすい本文（改行反映） %>
+          <div class="px-4 py-4 grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div>
+              <div class="text-xs font-semibold text-slate-500 mb-2">Before</div>
+              <pre class="rounded ring-1 ring-slate-200 bg-slate-50 p-3 max-h-[28rem] overflow-auto leading-relaxed whitespace-pre-wrap"><%= text_before %></pre>
+            </div>
+            <div>
+              <div class="text-xs font-semibold text-slate-500 mb-2">After</div>
+              <pre class="rounded ring-1 ring-slate-200 bg-emerald-50/40 p-3 max-h-[28rem] overflow-auto leading-relaxed whitespace-pre-wrap"><%= text_after %></pre>
+            </div>
+          </div>
+
+          <%# 簡易差分（行単位） %>
+          <% if diff[:added].present? || diff[:removed].present? %>
+            <div class="px-4 pb-4">
+              <div class="text-sm font-semibold text-slate-700 mb-2">差分（簡易）</div>
+              <% if diff[:added].present? %>
+                <div class="mb-2">
+                  <div class="text-xs text-emerald-700 font-semibold mb-1">追加された行</div>
+                  <ul class="text-sm list-disc pl-5">
+                    <% diff[:added].each do |line| %>
+                      <li class="text-emerald-700">+ <%= line %></li>
+                    <% end %>
+                  </ul>
+                </div>
+              <% end %>
+              <% if diff[:removed].present? %>
+                <div>
+                  <div class="text-xs text-rose-700 font-semibold mb-1">削除された行</div>
+                  <ul class="text-sm list-disc pl-5">
+                    <% diff[:removed].each do |line| %>
+                      <li class="text-rose-700">− <%= line %></li>
+                    <% end %>
+                  </ul>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+
+          <%# 必要な時だけHTMLソースを開く %>
+          <details class="px-4 pb-4">
+            <summary class="cursor-pointer text-sm text-slate-600 hover:text-slate-900 select-none">
+              HTMLソースを表示
+            </summary>
+            <div class="mt-3 grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div>
+                <div class="text-xs font-semibold text-slate-500 mb-2">Before（HTML）</div>
+                <pre class="rounded ring-1 ring-slate-200 bg-white p-3 text-xs overflow-auto max-h-[24rem]"><%= before %></pre>
+              </div>
+              <div>
+                <div class="text-xs font-semibold text-slate-500 mb-2">After（HTML）</div>
+                <pre class="rounded ring-1 ring-slate-200 bg-white p-3 text-xs overflow-auto max-h-[24rem]"><%= after %></pre>
+              </div>
+            </div>
+          </details>
+        </div>
+
+      <% else %>
+        <div class="rounded border overflow-hidden bg-white">
+          <div class="px-4 py-3 border-b font-semibold"><%= col %></div>
+          <div class="px-4 py-4 grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div>
+              <div class="text-xs font-semibold text-slate-500 mb-2">Before</div>
+              <div class="rounded ring-1 ring-slate-200 bg-slate-50 p-3 max-h-[18rem] overflow-auto">
+                <%= render partial: "value_cell", locals: { v: before } %>
+              </div>
+            </div>
+            <div>
+              <div class="text-xs font-semibold text-slate-500 mb-2">After</div>
+              <div class="rounded ring-1 ring-slate-200 bg-emerald-50/40 p-3 max-h-[18rem] overflow-auto">
+                <%= render partial: "value_cell", locals: { v: after } %>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+<% else %>
+  <p class="text-sm text-slate-600">diff 情報はありません。</p>
+<% end %>
+
+<div class="h-6"></div>

--- a/app/views/book_sections/edit.html.erb
+++ b/app/views/book_sections/edit.html.erb
@@ -1,0 +1,17 @@
+<!-- app/views/book_sections/edit.html.erb -->
+<% content_for :title, "セクション編集" %>
+<h1 class="text-xl font-semibold mb-4"><%= @book.title %> / <%= @section.heading %> を編集</h1>
+
+<%= form_with model: @section, url: book_section_path(@book, @section),
+              method: :patch, data: { controller: "quill" } do |f| %>
+  <%= f.hidden_field :lock_version %>
+  <div class="space-y-2">
+    <%= f.label :content, class: "block text-sm text-slate-600" %>
+    <div id="quill-editor" class="bg-white rounded min-h-[18rem] mb-6 ql-container ql-snow"></div>
+    <%= f.hidden_field :content, id: "content_field", autocomplete: "off" %>
+  </div>
+  <div class="mt-4">
+    <%= f.submit "更新する", class: "px-4 py-2 rounded bg-slate-900 text-white" %>
+    <%= link_to "戻る", book_section_path(@book, @section), class: "ml-2 underline" %>
+  </div>
+<% end %>

--- a/app/views/book_sections/show.html.erb
+++ b/app/views/book_sections/show.html.erb
@@ -8,6 +8,13 @@
     <%= link_to "← #{@book.title} に戻る", book_path(@book), class: "text-slate-600 hover:underline" %>
   </nav>
 
+  <% if can_edit?(@section) %>
+    <div class="mb-4">
+      <%= link_to "編集", edit_book_section_path(@book, @section),
+            class: "inline-block px-3 py-1 rounded bg-slate-900 text-white text-sm" %>
+    </div>
+  <% end %>
+
   <h1 class="text-2xl font-bold mb-3">
     <span class="text-slate-400 mr-2"><%= @section.position %>.</span>
     <%= @section.heading %>
@@ -33,4 +40,11 @@
       <% end %>
     </div>
   </div>
+
+  <% if can_edit?(@section) %>
+    <div class="mb-4">
+      <%= link_to "編集", edit_book_section_path(@book, @section),
+            class: "inline-block px-3 py-1 rounded bg-slate-900 text-white text-sm" %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -41,6 +41,8 @@
           <%= link_to "Quizzes",        admin_quizzes_path %>
           <%= link_to "Quiz Sections",  admin_quiz_sections_path %>
           <%= link_to "Quiz Questions", admin_quiz_questions_path %>
+          <%= link_to "Editor Permissions", admin_editor_permissions_path %>
+          <%= link_to "Versions", admin_versions_path %>
 
           <% if current_user&.admin? %>
             <%= button_to "Logout",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,10 @@
     <%# CSS / JS 読み込み %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+
+    <%# Quill CDN %>
+    <link href="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.snow.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.min.js"></script>
   </head>
 
   <body class="min-h-screen flex flex-col <%= @body_bg || 'bg-white' %> text-slate-800">

--- a/app/views/quizzes/sections/questions/answer.html.erb
+++ b/app/views/quizzes/sections/questions/answer.html.erb
@@ -18,4 +18,11 @@
       <%= link_to "結果を見る", result_quiz_section_path(@quiz, @section), class: "underline" %>
     <% end %>
   </div>
+
+  <% if can_edit?(@question) %>
+    <div class="mb-3">
+      <%= link_to "この問題を編集", edit_quiz_section_question_path(@quiz, @section, @question),
+            class: "inline-block px-3 py-1 rounded bg-slate-900 text-white text-sm" %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/quizzes/sections/questions/edit.html.erb
+++ b/app/views/quizzes/sections/questions/edit.html.erb
@@ -1,0 +1,28 @@
+<!-- app/views/quizzes/sections/questions/edit.html.erb -->
+<% content_for :title, "問題を編集" %>
+<h1 class="text-xl font-semibold mb-4"><%= @quiz.title %> / <%= @section.heading %> / Q<%= @question.position %> を編集</h1>
+
+<%= form_with model: @question, url: quiz_section_question_path(@quiz, @section, @question), method: :patch, local: true, class: "space-y-4" do |f| %>
+  <%= f.hidden_field :lock_version %>
+  <div>
+    <%= f.label :question, "問題文" %>
+    <%= f.text_area :question, rows: 3, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+  </div>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+    <div><%= f.label :choice1 %><%= f.text_field :choice1, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %></div>
+    <div><%= f.label :choice2 %><%= f.text_field :choice2, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %></div>
+    <div><%= f.label :choice3 %><%= f.text_field :choice3, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %></div>
+    <div><%= f.label :choice4 %><%= f.text_field :choice4, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %></div>
+  </div>
+  <div class="grid grid-cols-2 gap-3">
+    <div><%= f.label :correct_choice, "正解(1..4)" %><%= f.number_field :correct_choice, min: 1, max: 4, class: "w-24 rounded ring-1 ring-slate-300 px-3 py-2" %></div>
+  </div>
+  <div>
+    <%= f.label :explanation, "解説" %>
+    <%= f.text_area :explanation, rows: 4, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+  </div>
+  <div>
+    <%= f.submit "更新する", class: "px-4 py-2 rounded bg-slate-900 text-white" %>
+    <%= link_to "戻る", quiz_section_question_path(@quiz, @section, @question), class: "ml-2 underline" %>
+  </div>
+<% end %>

--- a/app/views/quizzes/sections/questions/show.html.erb
+++ b/app/views/quizzes/sections/questions/show.html.erb
@@ -28,16 +28,10 @@
     </div>
   <% end %>
 
-  <div class="flex justify-between mt-4">
-    <div>
-      <% if @prev_q %>
-        <%= link_to "← 前の問題", quiz_section_question_path(@quiz, @section, @prev_q), class: "underline" %>
-      <% end %>
+  <% if can_edit?(@question) %>
+    <div class="mb-3">
+      <%= link_to "この問題を編集", edit_quiz_section_question_path(@quiz, @section, @question),
+            class: "inline-block px-3 py-1 rounded bg-slate-900 text-white text-sm" %>
     </div>
-    <div>
-      <% if @next_q %>
-        <%= link_to "次の問題 →", quiz_section_question_path(@quiz, @section, @next_q), class: "underline" %>
-      <% end %>
-    </div>
-  </div>
+  <% end %>
 </div>

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,0 +1,5 @@
+# config/initializers/paper_trail.rb
+PaperTrail.configure do |config|
+  # 新規以降は JSON で保存（YAML の安全読み込み問題を回避）
+  config.serializer = PaperTrail::Serializers::JSON
+end

--- a/config/initializers/paper_trail_retention.rb
+++ b/config/initializers/paper_trail_retention.rb
@@ -1,0 +1,7 @@
+# config/initializers/paper_trail_retention.rb
+# PaperTrail の自動クリーンアップ設定
+Rails.application.configure do
+  config.x.versions.keep_per_item = ENV.fetch("VERSIONS_KEEP_PER_ITEM", 100).to_i       # 各 item の最大保持件数
+  config.x.versions.keep_days     = ENV.fetch("VERSIONS_KEEP_DAYS", 30).to_i            # 何日以内を保持するか
+  config.x.versions.cleanup_batch = ENV.fetch("VERSIONS_CLEANUP_BATCH", 1000).to_i      # 1回の削除件数
+end

--- a/config/initializers/yaml_permitted_classes.rb
+++ b/config/initializers/yaml_permitted_classes.rb
@@ -1,0 +1,19 @@
+# config/initializers/yaml_permitted_classes.rb
+# YAMLカラムで許可するクラスを追加
+permitted = [
+  Time, Date, Symbol,
+  ActiveSupport::TimeZone,
+  ActiveSupport::TimeWithZone
+]
+
+# Rails 7.1+ (推奨API)
+if ActiveRecord.respond_to?(:yaml_column_permitted_classes)
+  ActiveRecord.yaml_column_permitted_classes |= permitted
+end
+
+# 古いRails互換: YAMLColumnに直接設定
+if defined?(ActiveRecord::Coders::YAMLColumn) &&
+   ActiveRecord::Coders::YAMLColumn.respond_to?(:permitted_classes=)
+  current = ActiveRecord::Coders::YAMLColumn.permitted_classes || []
+  ActiveRecord::Coders::YAMLColumn.permitted_classes = (current | permitted)
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,15 +3,16 @@ ja:
   date:
     formats:
       default: "%Y/%m/%d"
-      short:   "%m/%d"
-      long:    "%Y年%-m月%-d日(%a)"
+      short: "%m/%d"
+      long: "%Y年%-m月%-d日(%a)"
       ymd_hm: "%Y/%m/%d %H:%M"
   time:
     formats:
       default: "%Y/%m/%d %H:%M"
-      short:   "%m/%d %H:%M"
-      long:    "%Y年%-m月%-d日 %H:%M"
-      ymd_hm:  "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+      long: "%Y年%-m月%-d日 %H:%M"
+      ymd_hm: "%Y/%m/%d %H:%M"
+
   activerecord:
     models:
       pre_code: "PreCode"
@@ -19,6 +20,7 @@ ja:
       quiz: "クイズ"
       quiz_section: "クイズセクション"
       quiz_question: "クイズ問題"
+
     attributes:
       book_section:
         book_id: "対象の教本"
@@ -27,6 +29,7 @@ ja:
         heading: "見出し"
         content: "本文"
         images: "画像（複数可）"
+        lock_version: "更新番号"
       pre_code:
         title: "タイトル"
         body: "コードの説明"
@@ -40,7 +43,6 @@ ja:
         position: "位置"
         created_at: "作成日時"
         updated_at: "更新日時"
-
       quiz_section:
         quiz: "クイズ"
         quiz_id: "クイズ"
@@ -49,7 +51,6 @@ ja:
         position: "位置"
         created_at: "作成日時"
         updated_at: "更新日時"
-
       quiz_question:
         quiz: "クイズ"
         quiz_id: "クイズ"
@@ -63,8 +64,10 @@ ja:
         correct_choice: "正解"
         explanation: "解説"
         position: "位置"
+        lock_version: "更新番号"
         created_at: "作成日時"
         updated_at: "更新日時"
+
     errors:
       models:
         book:
@@ -127,6 +130,7 @@ ja:
               not_a_number: "は数値で入力してください"
               not_an_integer: "は整数で入力してください"
               greater_than: "は%{count}より大きい値にしてください"
+
   helpers:
     submit:
       book_section:
@@ -143,6 +147,7 @@ ja:
       quiz_question:
         create: "作成する"
         update: "更新する"
+
   errors:
     messages:
       blank: "を入力してください"
@@ -165,8 +170,10 @@ ja:
       other_than: "は%{count}以外の値にしてください"
       odd: "は奇数を指定してください"
       even: "は偶数を指定してください"
+
   bookmarks:
     limit_reached: "300件以上のブックマーク登録はできません"
+
   search:
     no_items: "候補はありません"
     error: "通信エラー"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,4 @@
 Rails.application.routes.draw do
-  namespace :quizzes do
-    namespace :sections do
-      get "questions/show"
-    end
-    get "sections/index"
-    get "sections/show"
-  end
-  get "quizzes/index"
-  get "quizzes/show"
   # 静的ページ
   get "help",    to: "static_pages#help"
   get "terms",   to: "static_pages#terms"
@@ -59,13 +50,13 @@ Rails.application.routes.draw do
 
   # Rails Books
   resources :books, only: %i[index show] do
-    resources :sections, only: :show, controller: :book_sections
+    resources :sections, only: %i[show edit update], controller: :book_sections
   end
 
   # クイズ機能
   resources :quizzes, only: %i[index show] do
     resources :sections, only: %i[index show], module: :quizzes do
-      resources :questions, only: %i[show], module: :sections do
+      resources :questions, only: %i[show edit update], module: :sections do
         post :answer, on: :member
         get  :answer_page, on: :member
       end
@@ -75,27 +66,10 @@ Rails.application.routes.draw do
 
   # 管理画面
   namespace :admin do
-    get "quiz_questions/index"
-    get "quiz_questions/show"
-    get "quiz_questions/new"
-    get "quiz_questions/create"
-    get "quiz_questions/edit"
-    get "quiz_questions/update"
-    get "quiz_questions/destroy"
-    get "quiz_sections/index"
-    get "quiz_sections/show"
-    get "quiz_sections/new"
-    get "quiz_sections/create"
-    get "quiz_sections/edit"
-    get "quiz_sections/update"
-    get "quiz_sections/destroy"
-    get "quizzes/index"
-    get "quizzes/show"
-    get "quizzes/new"
-    get "quizzes/create"
-    get "quizzes/edit"
-    get "quizzes/update"
-    get "quizzes/destroy"
+    get "editor_permissions/index"
+    get "editor_permissions/new"
+    get "editor_permissions/create"
+    get "editor_permissions/destroy"
     root "dashboards#index"
 
     resource  :session,   only: %i[new create destroy]
@@ -115,6 +89,22 @@ Rails.application.routes.draw do
 
     resources :tags, only: %i[index destroy] do
       post :merge, on: :collection
+    end
+
+    resources :editor_permissions do
+      collection do
+        get  :bulk_new
+        post :bulk_create
+        get  :describe_target
+        get  :user_status
+      end
+    end
+
+    resources :versions, only: %i[index show destroy] do
+      post :revert, on: :member
+      collection do
+        delete :bulk_destroy
+      end
     end
   end
 

--- a/db/migrate/20251001044249_create_versions.rb
+++ b/db/migrate/20251001044249_create_versions.rb
@@ -1,0 +1,37 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[8.0]
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, null: false
+      t.bigint   :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.text     :object, limit: TEXT_BYTES
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      # MySQL users should use the following line for `created_at`
+      # t.datetime :created_at, limit: 6
+      t.datetime :created_at
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/migrate/20251001044250_add_object_changes_to_versions.rb
+++ b/db/migrate/20251001044250_add_object_changes_to_versions.rb
@@ -1,0 +1,12 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration[8.0]
+  # The largest text column available in all supported RDBMS.
+  # See `create_versions.rb` for details.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/migrate/20251001044538_create_editor_permissions.rb
+++ b/db/migrate/20251001044538_create_editor_permissions.rb
@@ -1,0 +1,16 @@
+class CreateEditorPermissions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :editor_permissions do |t|
+      t.references :user, null: false, foreign_key: true, index: true
+      t.string  :target_type, null: false
+      t.bigint  :target_id,   null: false
+      t.integer :role,        null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :editor_permissions, [ :user_id, :target_type, :target_id ],
+              unique: true, name: "index_editor_permissions_on_user_and_target"
+    add_index :editor_permissions, [ :target_type, :target_id ]
+  end
+end

--- a/db/migrate/20251001044757_add_lock_version_to_editable_models.rb
+++ b/db/migrate/20251001044757_add_lock_version_to_editable_models.rb
@@ -1,0 +1,6 @@
+class AddLockVersionToEditableModels < ActiveRecord::Migration[8.0]
+  def change
+    add_column :book_sections,  :lock_version, :integer, null: false, default: 0
+    add_column :quiz_questions, :lock_version, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_01_022057) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_01_044757) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -61,6 +61,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_022057) do
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "lock_version", default: 0, null: false
     t.index ["book_id", "position"], name: "index_book_sections_on_book_id_and_position", unique: true
     t.index ["book_id"], name: "index_book_sections_on_book_id"
   end
@@ -83,6 +84,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_022057) do
     t.integer "book_sections_count", default: 0, null: false
     t.integer "position", null: false
     t.index ["position"], name: "index_books_on_position", unique: true
+  end
+
+  create_table "editor_permissions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "target_type", null: false
+    t.bigint "target_id", null: false
+    t.integer "role", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["target_type", "target_id"], name: "index_editor_permissions_on_target_type_and_target_id"
+    t.index ["user_id", "target_type", "target_id"], name: "index_editor_permissions_on_user_and_target", unique: true
+    t.index ["user_id"], name: "index_editor_permissions_on_user_id"
   end
 
   create_table "likes", force: :cascade do |t|
@@ -135,6 +148,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_022057) do
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "lock_version", default: 0, null: false
     t.index ["quiz_id"], name: "index_quiz_questions_on_quiz_id"
     t.index ["quiz_section_id", "position"], name: "index_quiz_questions_on_quiz_section_id_and_position"
     t.index ["quiz_section_id"], name: "index_quiz_questions_on_quiz_section_id"
@@ -215,12 +229,24 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_022057) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token_unique", unique: true
   end
 
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object"
+    t.datetime "created_at"
+    t.text "object_changes"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "authentications", "users", on_delete: :cascade
   add_foreign_key "book_sections", "books"
   add_foreign_key "bookmarks", "pre_codes", on_delete: :cascade
   add_foreign_key "bookmarks", "users"
+  add_foreign_key "editor_permissions", "users"
   add_foreign_key "likes", "pre_codes"
   add_foreign_key "likes", "users"
   add_foreign_key "pre_code_taggings", "pre_codes", on_delete: :cascade

--- a/lib/tasks/versions.rake
+++ b/lib/tasks/versions.rake
@@ -1,0 +1,8 @@
+# lib/tasks/versions.rake
+namespace :versions do
+  desc "Clean up PaperTrail versions by age and per-item limit"
+  task cleanup: :environment do
+    VersionsCleanupJob.perform_now
+    puts "Versions cleanup finished."
+  end
+end

--- a/spec/factories/editor_permissions.rb
+++ b/spec/factories/editor_permissions.rb
@@ -1,0 +1,17 @@
+# spec/factories/editor_permissions.rb
+FactoryBot.define do
+  factory :editor_permission do
+    association :user
+    target_type { "BookSection" }
+    sequence(:target_id) { |n| n }
+    role { :sub_editor }  # ← enum は sub_editor のみ
+
+    trait :for_book_section do
+      target_type { "BookSection" }
+    end
+
+    trait :for_quiz_question do
+      target_type { "QuizQuestion" }
+    end
+  end
+end

--- a/spec/models/editor_permission_spec.rb
+++ b/spec/models/editor_permission_spec.rb
@@ -1,0 +1,46 @@
+# spec/models/editor_permission_spec.rb
+require "rails_helper"
+
+RSpec.describe EditorPermission, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe "enums" do
+    it "role は sub_editor を持つ" do
+      expect(described_class.roles.keys).to contain_exactly("sub_editor")
+    end
+  end
+
+  describe "validations" do
+    subject(:perm) { build(:editor_permission, user:, target_type: "BookSection", target_id: 1, role: :sub_editor) }
+    let(:user) { create(:user) }
+
+    it { is_expected.to validate_presence_of(:target_type) }
+    it { is_expected.to validate_presence_of(:target_id) }
+
+    it "target_id は数値のみ" do
+      perm.target_id = "abc"
+      expect(perm).to be_invalid
+      expect(perm.errors[:target_id]).to be_present
+    end
+
+    it "有効" do
+      expect(perm).to be_valid
+    end
+
+    it "user/target のユニーク制約（DBレベル）" do
+      described_class.create!(user:, target_type: "BookSection", target_id: 123, role: :sub_editor)
+      expect {
+        described_class.create!(user:, target_type: "BookSection", target_id: 123, role: :sub_editor)
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+
+  describe "#target_human_label" do
+    it "対象が存在しない場合はベース表記" do
+      perm = build(:editor_permission, target_type: "BookSection", target_id: 999_999)
+      expect(perm.target_human_label).to eq("BookSection#999999")
+    end
+  end
+end

--- a/spec/models/user_roles_spec.rb
+++ b/spec/models/user_roles_spec.rb
@@ -1,0 +1,60 @@
+# spec/models/user_roles_spec.rb
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  describe "#effective_role" do
+    let(:user) { create(:user, admin: false, editor: false) }
+
+    it "admin が最優先" do
+      user.update!(admin: true, editor: false)
+      expect(user.effective_role).to eq(:admin)
+    end
+
+    it "editor が次点" do
+      user.update!(admin: false, editor: true)
+      expect(user.effective_role).to eq(:editor)
+    end
+
+    it "sub_editor（個別権限あり）" do
+      user.update!(admin: false, editor: false)
+      create(:editor_permission, user:, target_type: "BookSection", target_id: 1, role: :sub_editor)
+      expect(user.effective_role).to eq(:sub_editor)
+    end
+
+    it "上記いずれでもなければ general" do
+      expect(user.effective_role).to eq(:general)
+    end
+  end
+
+  describe "#can_edit?" do
+    let!(:book)     { create(:book) }
+    let!(:section)  { create(:book_section, book:, is_free: true, position: 1) }
+    let!(:quiz)     { create(:quiz) }
+    let!(:qsec)     { create(:quiz_section, quiz:, is_free: true, position: 1) }
+    let!(:question) { create(:quiz_question, quiz:, quiz_section: qsec, position: 1) }
+
+    it "admin は常に true" do
+      admin = create(:user, admin: true)
+      expect(admin.can_edit?(section)).to be true
+      expect(admin.can_edit?(question)).to be true
+    end
+
+    it "editor は常に true" do
+      editor = create(:user, editor: true)
+      expect(editor.can_edit?(section)).to be true
+      expect(editor.can_edit?(question)).to be true
+    end
+
+    it "sub_editor は対象に限り true" do
+      sub = create(:user)
+      create(:editor_permission, user: sub, target_type: "BookSection", target_id: section.id, role: :sub_editor)
+      expect(sub.can_edit?(section)).to be true
+      expect(sub.can_edit?(question)).to be false
+    end
+
+    it "general は false" do
+      general = create(:user)
+      expect(general.can_edit?(section)).to be false
+    end
+  end
+end

--- a/spec/requests/admin/editor_permissions_ajax_spec.rb
+++ b/spec/requests/admin/editor_permissions_ajax_spec.rb
@@ -1,0 +1,55 @@
+# spec/requests/admin/editor_permissions_ajax_spec.rb
+require "rails_helper"
+
+RSpec.describe "Admin::EditorPermissions Ajax", type: :request do
+  let!(:admin) { create(:user, admin: true) }
+
+  before { sign_in(admin) }
+
+  describe "GET /admin/editor_permissions/describe_target" do
+    it "BookSection を整形して返す" do
+      book = create(:book, title: "B")
+      sec  = create(:book_section, book:, heading: "H")
+      get describe_target_admin_editor_permissions_path, params: { target_type: "BookSection", target_id: sec.id }
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["label"]).to include("BookSection##{sec.id}")
+      expect(json["label"]).to include("B").and include("H")
+    end
+
+    it "見つからない時でもベース表記を返す" do
+      get describe_target_admin_editor_permissions_path, params: { target_type: "QuizQuestion", target_id: 999_999 }
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["label"]).to eq("QuizQuestion#999999（見つかりません）")
+    end
+  end
+
+  describe "GET /admin/editor_permissions/user_status" do
+    it "admin を判定" do
+      get user_status_admin_editor_permissions_path, params: { user_id: admin.id }
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json).to include("ok" => true, "admin" => true, "editor" => false)
+      expect(json["label"]).to eq("管理者")
+    end
+
+    it "editor を判定" do
+      editor = create(:user, editor: true)
+      get user_status_admin_editor_permissions_path, params: { user_id: editor.id }
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json).to include("ok" => true, "admin" => false, "editor" => true)
+      expect(json["label"]).to eq("編集者")
+    end
+
+    it "一般ユーザー" do
+      u = create(:user)
+      get user_status_admin_editor_permissions_path, params: { user_id: u.id }
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json).to include("ok" => true, "admin" => false, "editor" => false)
+      expect(json["label"]).to be_nil
+    end
+  end
+end

--- a/spec/requests/admin/users_roles_spec.rb
+++ b/spec/requests/admin/users_roles_spec.rb
@@ -1,0 +1,25 @@
+# spec/requests/admin/users_roles_spec.rb
+require "rails_helper"
+
+RSpec.describe "Admin::Users badges", type: :request do
+  let!(:admin_user) { create(:user, admin: true) }
+
+  before { sign_in admin_user }
+
+  it "admin / editor / sub_editor / 一般 のバッジが表示される" do
+    u_admin  = create(:user, admin: true)
+    u_editor = create(:user, editor: true)
+    u_sub    = create(:user)
+    create(:editor_permission, user: u_sub, target_type: "BookSection", target_id: 1, role: :sub_editor)
+    u_gen    = create(:user)
+
+    get admin_users_path
+    expect(response).to have_http_status(:ok)
+
+    # 文字列マッチ（ビュー側のバッジラベルに追随）
+    expect(response.body).to include("管理者")     # admin
+    expect(response.body).to include("編集者")     # editor
+    expect(response.body).to include("sub_editor") # sub_editor
+    expect(response.body).to include("一般")       # general
+  end
+end

--- a/spec/requests/collab_edit_book_sections_spec.rb
+++ b/spec/requests/collab_edit_book_sections_spec.rb
@@ -1,0 +1,117 @@
+# spec/requests/collab_edit_book_sections_spec.rb
+require "rails_helper"
+
+RSpec.describe "Collaborative edit: BookSection", type: :request do
+  let!(:book)    { create(:book) }
+  let!(:section) { create(:book_section, book:, is_free: true, position: 1, content: "<p>old</p>") }
+
+  let!(:editor)  { create(:user, admin: false, editor: false, password: "secret123", password_confirmation: "secret123") }
+  let!(:admin)   { create(:user, admin: true,  editor: false, password: "secret123", password_confirmation: "secret123") }
+  let!(:normal)  { create(:user, admin: false, editor: false, password: "secret123", password_confirmation: "secret123") }
+
+  before do
+    # enum は sub_editor のみ
+    EditorPermission.create!(user: editor, target_type: "BookSection", target_id: section.id, role: :sub_editor)
+  end
+
+  describe "閲覧/編集リンク" do
+    it "権限ユーザーには編集リンクが見える" do
+      sign_in(editor)
+      get book_section_path(book, section)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(edit_book_section_path(book, section))
+    end
+
+    it "一般ユーザーには編集リンクが出ない" do
+      sign_in(normal)
+      get book_section_path(book, section)
+      expect(response.body).not_to include(edit_book_section_path(book, section))
+    end
+  end
+
+  describe "編集可否" do
+    it "権限ユーザーは編集できる" do
+      sign_in(editor)
+      get edit_book_section_path(book, section)
+      expect(response).to have_http_status(:ok)
+
+      expect {
+        patch book_section_path(book, section), params: {
+          book_section: { content: "<p>updated</p>", lock_version: section.lock_version }
+        }
+      }.to change { section.reload.content }.to("<p>updated</p>")
+
+      expect(response).to redirect_to(book_section_path(book, section))
+    end
+
+    it "管理者は権限付与がなくても編集できる" do
+      sign_in(admin)
+      patch book_section_path(book, section), params: {
+        book_section: { content: "<p>admin</p>", lock_version: section.lock_version }
+      }
+      expect(response).to redirect_to(book_section_path(book, section))
+      expect(section.reload.content).to eq("<p>admin</p>")
+    end
+
+    it "一般ユーザーは 302（権限なし）" do
+      sign_in(normal)
+      get edit_book_section_path(book, section)
+      expect(response).to have_http_status(:found).or have_http_status(:see_other)
+    end
+  end
+
+  describe "サニタイズ/許可属性" do
+    it "script タグは除去される" do
+      sign_in(editor)
+      patch book_section_path(book, section), params: {
+        book_section: { content: %(<p>a</p><script>alert(1)</script>), lock_version: section.lock_version }
+      }
+      follow_redirect!
+      expect(response.body).to include("<p>a</p>")
+      expect(response.body).not_to include("<script>")
+    end
+
+    it "position 等は更新できない（一般編集者）" do
+      sign_in(editor)
+      original = section.position
+      patch book_section_path(book, section), params: {
+        book_section: {
+          content: "<p>keep</p>",
+          position: original + 5,      # 許可されていない
+          lock_version: section.lock_version
+        }
+      }
+      expect(section.reload.position).to eq(original)
+      expect(section.content).to eq("<p>keep</p>")
+    end
+  end
+
+  describe "PaperTrail" do
+    it "更新すると version が増える" do
+      sign_in(editor)
+      expect {
+        patch book_section_path(book, section), params: {
+          book_section: { content: "<p>v2</p>", lock_version: section.lock_version }
+        }
+      }.to change { section.reload.versions.count }.by(1)
+    end
+  end
+
+  describe "optimistic locking" do
+    it "ロック競合時は 409 で、内容は更新されない" do
+      sign_in(editor)
+
+      section.update!(content: "v1")
+      stale = section.reload.lock_version
+      section.update!(content: "v2") # lock_version 前進
+
+      expect {
+        patch book_section_path(book, section), params: {
+          book_section: { content: "v3", lock_version: stale }
+        }
+        expect(response).to have_http_status(:conflict)
+      }.not_to change { section.reload.content }
+      expect(response.body).to include("競合")
+    end
+  end
+end

--- a/spec/requests/collab_edit_quiz_questions_spec.rb
+++ b/spec/requests/collab_edit_quiz_questions_spec.rb
@@ -1,0 +1,92 @@
+# spec/requests/collab_edit_quiz_questions_spec.rb
+require "rails_helper"
+
+RSpec.describe "Collaborative edit: QuizQuestion", type: :request do
+  let!(:quiz)     { create(:quiz) }
+  let!(:section)  { create(:quiz_section, quiz:, is_free: true, position: 1) }
+  let!(:question) { create(:quiz_question, quiz:, quiz_section: section, position: 1, question: "Q1") }
+
+  let!(:editor)   { create(:user, password: "secret123", password_confirmation: "secret123") }
+  let!(:admin)    { create(:user, admin: true, password: "secret123", password_confirmation: "secret123") }
+  let!(:normal)   { create(:user, password: "secret123", password_confirmation: "secret123") }
+
+  before do
+    EditorPermission.create!(user: editor, target_type: "QuizQuestion", target_id: question.id, role: :sub_editor)
+  end
+
+  describe "編集" do
+    it "権限ユーザーは問題を更新できる" do
+      sign_in(editor)
+
+      expect {
+        patch quiz_section_question_path(quiz, section, question), params: {
+          quiz_question: { question: "書き換え？", explanation: "exp", lock_version: question.lock_version }
+        }
+      }.to change { question.reload.question }.to("書き換え？")
+
+      expect(response).to redirect_to(quiz_section_question_path(quiz, section, question))
+      follow_redirect!
+      expect(response.body).to include("書き換え？")
+    end
+
+    it "管理者は権限無しでも更新できる" do
+      sign_in(admin)
+      patch quiz_section_question_path(quiz, section, question), params: {
+        quiz_question: { question: "admin update", lock_version: question.lock_version }
+      }
+      expect(response).to redirect_to(quiz_section_question_path(quiz, section, question))
+      expect(question.reload.question).to eq("admin update")
+    end
+
+    it "一般ユーザーは 302（権限なし）" do
+      sign_in(normal)
+      patch quiz_section_question_path(quiz, section, question), params: {
+        quiz_question: { question: "nope", lock_version: question.lock_version }
+      }
+      expect(response).to have_http_status(:found).or have_http_status(:see_other)
+      expect(question.reload.question).to eq("Q1")
+    end
+  end
+
+  describe "許可属性のみ更新" do
+    it "position は更新されない" do
+      sign_in(editor)
+      original = question.position
+      patch quiz_section_question_path(quiz, section, question), params: {
+        quiz_question: {
+          question: "keep",
+          position: original + 10, # 許可されていない
+          lock_version: question.lock_version
+        }
+      }
+      expect(question.reload.position).to eq(original)
+      expect(question.question).to eq("keep")
+    end
+  end
+
+  describe "PaperTrail" do
+    it "更新で version が増える" do
+      sign_in(editor)
+      expect {
+        patch quiz_section_question_path(quiz, section, question), params: {
+          quiz_question: { question: "v2", lock_version: question.lock_version }
+        }
+      }.to change { question.reload.versions.count }.by(1)
+    end
+  end
+
+  describe "optimistic locking" do
+    it "ロック競合は 409" do
+      sign_in(editor)
+      question.update!(question: "v1")
+      stale = question.reload.lock_version
+      question.update!(question: "v2")
+
+      patch quiz_section_question_path(quiz, section, question), params: {
+        quiz_question: { question: "v3", lock_version: stale }
+      }
+      expect(response).to have_http_status(:conflict)
+      expect(question.reload.question).to eq("v2")
+    end
+  end
+end


### PR DESCRIPTION
### 概要
教本・クイズの共同編集機能を仕上げ、管理UIと認可周りに合わせて RSpec を全面更新した。

**作業内容**

- EditorPermission を sub_editor 単一 enum に整理し、Factory/Spec を統一
- User#effective_role と #can_edit? をモデルスペックで網羅（admin > editor > sub_editor > general）
- 書籍/クイズの編集リクエストスペックを刷新し、optimistic locking・PaperTrail・サニタイズ・許可属性を検証
- 管理UIの Ajax（describe_target / user_status）とユーザー一覧の権限バッジ表示をリクエストスペックで追加検証
- 既存のテストフローに沿う形で sign_in 前提の実装に調整（追加のDB変更やルーティング変更は無し）