### PR TITLE
本リリース実装によって発生した、各機能の様々な不具合をまとめて修正した

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -6,22 +6,39 @@
 .content-body h2 { font-size: 1.5rem;  font-weight: 700; margin: 1.25rem 0 .75rem; }
 .content-body h3 { font-size: 1.25rem; font-weight: 700; margin: 1rem 0 .5rem; }
 
-.content-body p  { margin: 1rem 0; line-height: 1.8; }
+/* ★ 行間を 1.8 → 1.5 に詰める */
+.content-body p  { margin: 1rem 0; line-height: 1.5; }
 .content-body a  { color: #0369a1; text-decoration: underline; }
 
-.content-body ul { list-style: disc;    padding-left: 1.5rem; margin: 1rem 0; }
-.content-body ol { list-style: decimal; padding-left: 1.5rem; margin: 1rem 0; }
+.content-body ul { list-style: disc;    padding-left: 1.5rem; margin: 1rem 0; line-height: 1.5; }
+.content-body ol { list-style: decimal; padding-left: 1.5rem; margin: 1rem 0; line-height: 1.5; }
 
 .content-body blockquote {
-  border-left: 4px solid #e2e8f0; padding-left: 1rem; color: #475569; margin: 1rem 0;
+  border-left: 4px solid #e2e8f0; padding-left: 1rem; color: #475569; margin: 1rem 0; line-height: 1.5;
 }
 
+/* コードブロックのベース */
 .content-body pre {
-  background: #0f172a; color: #e2e8f0; padding: 1rem; border-radius: .5rem;
-  overflow-x: auto; line-height: 1.6;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1rem;
+  border-radius: .5rem;
+  overflow-x: auto;
+  line-height: 1.45;
 }
-.content-body code, .content-body pre, .content-body pre code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+
+/* highlight.js が吐く .hljs に余白を少し */
+.content-body pre code.hljs {
+  display: block;
+  padding: 0;
+}
+
+/* 行内コード */
+.content-body :not(pre) > code {
+  background: #f1f5f9;
+  color: #0f172a;
+  padding: .15rem .35rem;
+  border-radius: .35rem;
 }
 
 /* Quill のコードブロック用クラス */
@@ -30,12 +47,12 @@
 /* content-body 内の <hr> を見やすく */
 .content-body hr {
   border: 0;
-  border-top: 1px solid #e5e7eb; /* slate-200 */
-  margin: 1.25rem 0;             /* 上下余白 */
+  border-top: 1px solid #e5e7eb;
+  margin: 1.25rem 0;
   width: 100%;
 }
 
-/* Tailwind の @apply で共通ボタンを作る */
+/* 共通ボタン */
 .btn-dark{
   @apply inline-flex items-center justify-center
          rounded px-3 py-1 text-sm font-medium
@@ -46,11 +63,11 @@
          focus:outline-none focus:ring-2 focus:ring-slate-500;
 }
 
-/* Quill ツールバーを画面上部に固定 */
+/* Quill ツールバー固定 */
 .ql-toolbar {
   position: sticky;
-  top: 0;               /* 画面の一番上に固定 */
-  z-index: 50;          /* ヘッダーより上に出すなら調整 */
-  background: #fff;     /* 背景色を固定しないと透ける */
-  border-bottom: 1px solid #e5e7eb; /* 下線を追加して区切り感を出す */
+  top: 0;
+  z-index: 50;
+  background: #fff;
+  border-bottom: 1px solid #e5e7eb;
 }

--- a/app/controllers/admin/book_sections_controller.rb
+++ b/app/controllers/admin/book_sections_controller.rb
@@ -1,64 +1,48 @@
 # app/controllers/admin/book_sections_controller.rb
 # 管理: 書籍セクション
-# - create/update 前に content を sanitize（既存）
-# - 保存後: content 内の <img src="/rails/active_storage/.../:signed_id/..."> を拾って attach
-# - update 時: いまの content に出てこない画像を prune（任意機能）
+# - 保存前に content を許可リストで sanitize
+# - 保存後は本文から ActiveStorage の signed_id を拾って attach/prune
 class Admin::BookSectionsController < Admin::BaseController
-  include ActionView::Helpers::SanitizeHelper
   layout "admin"
 
-  # 一覧
   def index
     @sections = BookSection.includes(:book).order(updated_at: :desc).page(params[:page])
   end
 
-  # 新規
   def new
     @section = BookSection.new
   end
 
-  # 作成
   def create
     @section = BookSection.new(section_params)
-
-    # ① XSS 対策: 保存前に許可リストでサニタイズ
-    @section.content = sanitize_content(@section.content)
+    @section.content = RichTextSanitizer.call(@section.content)
 
     if @section.save
-      # ② 本文に含まれる signed_id を抽出して ActiveStorage に attach
       attach_images_from_content!(@section)
-
       redirect_to admin_book_sections_path, notice: "作成しました"
     else
       render :new, status: :unprocessable_entity
     end
   end
 
-  # 編集
   def edit
     @section = BookSection.find(params[:id])
   end
 
-  # 更新
   def update
     @section = BookSection.find(params[:id])
 
-    # Strong Params を受けてから content だけサニタイズして差し替え
     attrs = section_params
-    attrs[:content] = sanitize_content(attrs[:content])
+    attrs[:content] = RichTextSanitizer.call(attrs[:content])
 
     if @section.update(attrs)
-      # ③ update 後に再スキャンして attach。
-      #    prune: true の時は、本文から消えた画像を purge（整理）する
       attach_images_from_content!(@section, prune: true)
-
       redirect_to admin_book_sections_path, notice: "更新しました"
     else
       render :edit, status: :unprocessable_entity
     end
   end
 
-  # 削除
   def destroy
     BookSection.find(params[:id]).destroy
     redirect_to admin_book_sections_path, notice: "削除しました"
@@ -66,38 +50,19 @@ class Admin::BookSectionsController < Admin::BaseController
 
   private
 
-  # ==== Strong Params =========================================================
   def section_params
-    # ActiveStorage 複数添付は images: [] で受ける（既存）
-    params.require(:book_section).permit(:book_id, :heading, :content, :position, :is_free, images: [])
+    params.require(:book_section)
+          .permit(:book_id, :heading, :content, :position, :is_free, :quiz_section_id, images: [])
   end
 
-  # ==== サニタイズ（保存前フィルタ）============================================
-  # 表示側で html_safe にしない運用でも安全だが、二重防御として sanitize する
-  def sanitize_content(html)
-    sanitize(
-      html,
-      tags: %w[p h1 h2 h3 h4 h5 h6 b i u strong em a ul ol li pre code blockquote br span div img hr],
-      attributes: %w[href class target rel src alt style]
-    )
-  end
-
-  # ==== 本文から signed_id を拾って attach / prune =============================
-  # /rails/active_storage/blobs/:signed_id/... あるいは
-  # /rails/active_storage/blobs/redirect/:signed_id/... のどちらも拾う
   SIGNED_ID_IMG_SRC =
     %r{/rails/active_storage/(?:blobs|representations)(?:/redirect)?/([A-Za-z0-9_\-=]+)}.freeze
 
-  # @param section [BookSection]
-  # @param prune [Boolean] true のとき、本文に出てこない既存添付を purge する
   def attach_images_from_content!(section, prune: false)
     return if section.content.blank?
-
-    # 1) 本文から signed_id を収集
     signed_ids = section.content.scan(SIGNED_ID_IMG_SRC).flatten.uniq
     return if signed_ids.empty?
 
-    # 2) signed_id → Blob へ安全に解決（壊れたIDはスキップ）
     blobs = signed_ids.filter_map do |sid|
       begin
         ActiveStorage::Blob.find_signed(sid)
@@ -106,13 +71,9 @@ class Admin::BookSectionsController < Admin::BaseController
       end
     end
 
-    # 3) 新規 attach（既に同一 blob が付いているものはスキップ）
     current_blob_ids = section.images.attachments.map(&:blob_id)
-    blobs.reject { |b| current_blob_ids.include?(b.id) }.each do |blob|
-      section.images.attach(blob)
-    end
+    blobs.reject { |b| current_blob_ids.include?(b.id) }.each { |blob| section.images.attach(blob) }
 
-    # 4) prune: true の場合、本文に出ない画像を削除してクリーンアップ
     if prune
       keep_ids = blobs.map(&:id)
       section.images.attachments.reject { |att| keep_ids.include?(att.blob_id) }.each(&:purge)

--- a/app/controllers/admin/quiz_questions_controller.rb
+++ b/app/controllers/admin/quiz_questions_controller.rb
@@ -1,16 +1,20 @@
 # app/controllers/admin/quiz_questions_controller.rb
 class Admin::QuizQuestionsController < Admin::BaseController
   layout "admin"
+  before_action :set_question, only: %i[edit update destroy]
 
   def index
-    @questions = QuizQuestion.includes(:quiz, :quiz_section).order(updated_at: :desc).page(params[:page])
+    @questions = QuizQuestion.includes(:quiz, :quiz_section)
+                             .order(created_at: :desc)
+                             .page(params[:page])
   end
 
-  def new    = @question = QuizQuestion.new
-  def edit   = @question = QuizQuestion.find(params[:id])
+  def new
+    @question = QuizQuestion.new
+  end
 
   def create
-    @question = QuizQuestion.new(question_params)
+    @question = QuizQuestion.new(sanitized_params)
     if @question.save
       redirect_to admin_quiz_questions_path, notice: "作成しました"
     else
@@ -18,9 +22,10 @@ class Admin::QuizQuestionsController < Admin::BaseController
     end
   end
 
+  def edit; end
+
   def update
-    @question = QuizQuestion.find(params[:id])
-    if @question.update(question_params)
+    if @question.update(sanitized_params)
       redirect_to admin_quiz_questions_path, notice: "更新しました"
     else
       render :edit, status: :unprocessable_entity
@@ -28,17 +33,28 @@ class Admin::QuizQuestionsController < Admin::BaseController
   end
 
   def destroy
-    QuizQuestion.find(params[:id]).destroy
+    @question.destroy
     redirect_to admin_quiz_questions_path, notice: "削除しました"
   end
 
   private
 
+  def set_question
+    @question = QuizQuestion.find(params[:id])
+  end
+
   def question_params
     params.require(:quiz_question).permit(
-      :quiz_id, :quiz_section_id, :question,
-      :choice1, :choice2, :choice3, :choice4,
-      :correct_choice, :explanation, :position
+      :quiz_id, :quiz_section_id, :question, :choice1, :choice2, :choice3, :choice4,
+      :correct_choice, :position, :explanation
     )
+  end
+
+  # Quill の HTML を保存前に“同じ許可リスト”でサニタイズ
+  def sanitized_params
+    attrs = question_params.dup
+    attrs[:question]    = RichTextSanitizer.call(attrs[:question])
+    attrs[:explanation] = RichTextSanitizer.call(attrs[:explanation])
+    attrs
   end
 end

--- a/app/controllers/admin/quiz_sections_controller.rb
+++ b/app/controllers/admin/quiz_sections_controller.rb
@@ -35,6 +35,6 @@ class Admin::QuizSectionsController < Admin::BaseController
   private
 
   def section_params
-    params.require(:quiz_section).permit(:quiz_id, :heading, :is_free, :position)
+    params.require(:quiz_section).permit(:quiz_id, :heading, :is_free, :position, :book_section_id)
   end
 end

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -4,7 +4,8 @@ class Admin::TagsController < Admin::BaseController
 
   def index
     @q = params[:q].to_s
-    @tags = Tag.used.prefix(@q).order_for_suggest.page(params[:page])
+    # 未使用も含めて一覧表示（used を外す）
+    @tags = Tag.prefix(@q).order_for_suggest.page(params[:page])
   end
 
   def merge
@@ -17,7 +18,7 @@ class Admin::TagsController < Admin::BaseController
       PreCodeTagging.group(:pre_code_id, :tag_id).having("COUNT(*) > 1").pluck(:pre_code_id, :tag_id).each do |pid, tid|
         PreCodeTagging.where(pre_code_id: pid, tag_id: tid).offset(1).delete_all
       end
-      # カウンタ再計算（簡易）
+      # カウンタ再計算
       Tag.reset_counters(to.id, :pre_code_taggings)
       Tag.reset_counters(from.id, :pre_code_taggings)
       from.destroy! if from.taggings_count.zero?

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -8,12 +8,21 @@ class Admin::UsersController < Admin::BaseController
     @q = params[:q]
     @filter = params[:filter]
 
-    @users = User.search(@q)
-                 .yield_self { |u| @filter == "editors" ? u.editors : u }
-                 .yield_self { |u| @filter == "banned"  ? u.banned  : u }
-                 .includes(:editor_permissions)
-                 .order(created_at: :desc)
-                 .page(params[:page]).per(50)
+    users = User.all
+    if @q.present?
+      if @q.to_s =~ /\A\d+\z/
+        users = users.where(id: @q.to_i)
+      else
+        users = users.search(@q)
+      end
+    end
+
+    @users = users
+               .yield_self { |u| @filter == "editors" ? u.editors : u }
+               .yield_self { |u| @filter == "banned"  ? u.banned  : u }
+               .includes(:editor_permissions)
+               .order(created_at: :desc)
+               .page(params[:page]).per(50)
   end
 
   def toggle_editor

--- a/app/controllers/admin/versions_controller.rb
+++ b/app/controllers/admin/versions_controller.rb
@@ -14,6 +14,9 @@ class Admin::VersionsController < Admin::BaseController
   def show
     @version = PaperTrail::Version.find(params[:id])
     @record  = safe_reify(@version) # create のときは nil
+
+    # BookSection 用 fallback（changesetにcontentが無くても拾う）
+    @content_before, @content_after = field_before_after(@version, :content)
   end
 
   def revert
@@ -21,7 +24,6 @@ class Admin::VersionsController < Admin::BaseController
     record  = safe_reify(version)
 
     if record.nil?
-      # create の巻き戻し = 現在存在するレコードを削除
       model_klass = safe_model_for_item_type(version.item_type)
       if model_klass
         model_klass.find_by(id: version.item_id)&.destroy!
@@ -36,14 +38,12 @@ class Admin::VersionsController < Admin::BaseController
                 notice: "この版にロールバックしました"
   end
 
-  # ＝＝＝＝ 単体削除 ＝＝＝＝
   def destroy
     v = PaperTrail::Version.find(params[:id])
     v.destroy
     redirect_back fallback_location: admin_versions_path, notice: "版を削除しました"
   end
 
-  # ＝＝＝＝ 一括削除 ＝＝＝＝
   def bulk_destroy
     ids = Array(params[:version_ids]).map(&:to_i).uniq
     if ids.empty?
@@ -58,15 +58,12 @@ class Admin::VersionsController < Admin::BaseController
 
   # YAML/JSON どちらでも安全に reify する
   def safe_reify(version)
-    # まず JSON (現行設定) でトライ
     version.reify
   rescue JSON::ParserError
-    # YAML の可能性が高い → YAML serializer で再トライ
     PaperTrail.serializer = PaperTrail::Serializers::YAML
     begin
       version.reify
     ensure
-      # 終わったら必ず JSON に戻す
       PaperTrail.serializer = PaperTrail::Serializers::JSON
     end
   rescue Psych::DisallowedClass
@@ -74,26 +71,8 @@ class Admin::VersionsController < Admin::BaseController
     retry
   end
 
-  # 一時的に PaperTrail の serializer を YAML にしてブロックを実行
-  def with_yaml_serializer
-    PaperTrail.request do |req|
-      prev = req.serializer
-      req.serializer = PaperTrail::Serializers::YAML
-      begin
-        return yield
-      ensure
-        req.serializer = prev
-      end
-    end
-  end
-
-  # YAML 安全読み込みの許可クラスを追加
   def permit_yaml_classes!
-    permitted = [
-      Time, Date, Symbol,
-      ActiveSupport::TimeZone,
-      ActiveSupport::TimeWithZone
-    ]
+    permitted = [ Time, Date, Symbol, ActiveSupport::TimeZone, ActiveSupport::TimeWithZone ]
     if ActiveRecord.respond_to?(:yaml_column_permitted_classes)
       ActiveRecord.yaml_column_permitted_classes |= permitted
     end
@@ -103,5 +82,38 @@ class Admin::VersionsController < Admin::BaseController
     type = item_type.to_s
     return nil unless ALLOWED_ITEM_TYPES.include?(type)
     type.safe_constantize
+  end
+
+  # ---- 指定カラムの before/after を、changeset に無い場合でも再構築 ----
+  def field_before_after(version, column)
+    col = column.to_s
+    cs  = version.changeset || {}
+    if cs.key?(col)
+      before, after = cs[col]
+      return [ before, after ]
+    end
+
+    # update: reify が「更新前」。現在（または next 版の reify）が「更新後」
+    if version.event == "update"
+      before_rec = safe_reify(version)
+      after_rec  = version.next ? safe_reify(version.next) : version.item_type.constantize.find_by(id: version.item_id)
+      return [ before_rec&.public_send(col), after_rec&.public_send(col) ]
+    end
+
+    # create: after のみ
+    if version.event == "create"
+      after_rec = version.next ? safe_reify(version.next) : version.item_type.constantize.find_by(id: version.item_id)
+      return [ nil, after_rec&.public_send(col) ]
+    end
+
+    # destroy: before のみ
+    if version.event == "destroy"
+      before_rec = safe_reify(version)
+      return [ before_rec&.public_send(col), nil ]
+    end
+
+    [ nil, nil ]
+  rescue
+    [ nil, nil ]
   end
 end

--- a/app/controllers/editor_controller.rb
+++ b/app/controllers/editor_controller.rb
@@ -1,13 +1,31 @@
 # app/controllers/editor_controller.rb
 class EditorController < ApplicationController
-  # JSON以外は弾く（明示的に406を返す）
+  # JSON 以外は弾く
   before_action :ensure_json!, only: %i[create pre_code_body]
   protect_from_forgery with: :null_session, only: :create
 
+  # 制御文字（NULL 〜 US、DEL など）を禁止
+  FORBIDDEN_CTRL_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/.freeze
+  MAX_CODE_BYTES = 200_000 # 既存仕様を維持
+
   # GET /editor
   def index
-    @my_pre_codes = logged_in? ? current_user.pre_codes.order(created_at: :desc).limit(30) : PreCode.none
-    @popular_public = PreCode.order(like_count: :desc).limit(30)
+    if logged_in?
+      # 自分のデータ
+      @own_pre_codes = current_user.pre_codes.order(created_at: :desc).limit(100)
+
+      # ブックマークしたデータ（自分の分は除外して重複排除）
+      bookmarked_ids = Bookmark.where(user_id: current_user.id).select(:pre_code_id)
+      @bookmarked_pre_codes =
+        PreCode.includes(:user)
+               .where(id: bookmarked_ids)
+               .where.not(user_id: current_user.id)
+               .order(created_at: :desc)
+               .limit(100)
+    else
+      @own_pre_codes = PreCode.none
+      @bookmarked_pre_codes = PreCode.none
+    end
   end
 
   # POST /editor
@@ -15,39 +33,52 @@ class EditorController < ApplicationController
     code    = params[:code].to_s
     lang_id = params[:language_id].presence || Judge0::Client::RUBY_LANG_ID
 
-    # 空や過大リクエストの防御
     if code.strip.empty?
-      render json: { stdout: "", stderr: "code が空です" }, status: :unprocessable_entity and return
+      render json: { stdout: "", stderr: I18n.t!("editor.errors.blank") }, status: :unprocessable_entity and return
     end
-    if code.bytesize > 200_000
-      render json: { stdout: "", stderr: "code が大きすぎます" }, status: :unprocessable_entity and return
+    if code.bytesize > MAX_CODE_BYTES
+      render json: { stdout: "", stderr: I18n.t!("editor.errors.too_large") }, status: :unprocessable_entity and return
+    end
+    if code.match?(FORBIDDEN_CTRL_RE)
+      render json: { stdout: "", stderr: I18n.t!("editor.errors.forbidden_chars") }, status: :unprocessable_entity and return
     end
 
-    # Judge0 実行
     result = Judge0::Client.new.run_ruby(code, language_id: lang_id)
-
-    # **stdout / stderr のみ返す**
-    render json: {
-      stdout: result["stdout"] || "",
-      stderr: result["stderr"] || ""
-    }
+    render json: { stdout: result["stdout"] || "", stderr: result["stderr"] || "" }
   rescue Judge0::Error => e
     render json: { stdout: "", stderr: e.message }, status: :bad_gateway
   end
 
-  # GET /pre_codes/:id/body
+  # GET /pre_codes/:id/body  （エディタ用：詳細もまとめて返す）
   def pre_code_body
     pc = PreCode.find(params[:id])
-    render json: { id: pc.id, title: pc.title, body: pc.body }
+
+    # 「問題モード」判定：answer/answer_code どちらかがあれば true
+    is_quiz = pc.answer.present? || pc.answer_code.present?
+
+    sanitize_html = lambda do |html|
+      ActionController::Base.helpers.sanitize(
+        html.to_s,
+        tags:  %w[b i em strong code pre br p ul ol li a],
+        attributes: %w[href]
+      )
+    end
+
+    render json: {
+      id: pc.id,
+      title: pc.title,
+      description_html: sanitize_html.call(pc.description),
+      body: pc.body,
+      is_quiz: is_quiz,
+      hint_html: sanitize_html.call(pc.hint),
+      answer_html: sanitize_html.call(pc.answer),
+      answer_code: pc.answer_code.to_s
+    }
   rescue ActiveRecord::RecordNotFound
     render json: { error: "not found" }, status: :not_found
   end
 
   private
-
-  def judge0
-    @judge0 ||= Judge0::Client.new
-  end
 
   def ensure_json!
     return if request.format.json?

--- a/app/controllers/pre_codes_controller.rb
+++ b/app/controllers/pre_codes_controller.rb
@@ -24,7 +24,8 @@ class PreCodesController < ApplicationController
     end
 
     @q = base.ransack(params[:q])
-    @pre_codes = @q.result.order(id: :desc).page(params[:page])
+    # ★ Bullet (N+1) 対策
+    @pre_codes = @q.result.order(id: :desc).preload(:tags).page(params[:page])
   end
 
   def show; end
@@ -73,7 +74,6 @@ class PreCodesController < ApplicationController
       :quiz_mode
     )
 
-    # テキストだけサニタイズ
     sanitizer = if respond_to?(:sanitize_content, true)
                   method(:sanitize_content)
     else

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,16 +1,34 @@
 # app/controllers/tags_controller.rb
 class TagsController < ApplicationController
+  # インクリメンタル候補（従来どおり使用中のみ）
   def index
-    # 候補API: /tags.json?query=ru
     @tags = Tag.used.prefix(params[:query]).order_for_suggest.limit(20)
     respond_to do |f|
-      f.html { redirect_to root_path } # 画面不要
-      f.json { render json: @tags.as_json(only: [ :id, :name, :slug, :color ]) }
+      f.html { redirect_to root_path }
+      f.json { render json: @tags.as_json(only: [ :id, :name, :slug, :color, :taggings_count ]) }
     end
   end
 
+  # タグピッカー用：未使用も含めて人気順（利用数降順、name_norm昇順）
+  def popular
+    rel = Tag.order(taggings_count: :desc, name_norm: :asc)
+    rel = rel.where("name_norm LIKE ?", "#{Tag.normalize(params[:q])}%") if params[:q].present?
+    @tags = rel.limit(200)
+    render json: @tags.as_json(only: [ :id, :name, :slug, :color, :taggings_count ])
+  end
+
+  # 新規タグ作成（JSON）
+  def create
+    name = params.require(:tag).permit(:name)[:name]
+    tag  = Tag.find_by(name_norm: Tag.normalize(name)) || Tag.create!(name: name)
+    render json: tag.as_json(only: [ :id, :name, :slug, :color, :taggings_count ]), status: :created
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
+  end
+
+  # 既存
   def show
     @tag = Tag.find_by!(slug: params[:id])
-    redirect_to pre_codes_path(tags: @tag.name) # 既存一覧を流用
+    redirect_to pre_codes_path(tags: @tag.name)
   end
 end

--- a/app/helpers/admin/versions_helper.rb
+++ b/app/helpers/admin/versions_helper.rb
@@ -1,22 +1,31 @@
 # app/helpers/admin/versions_helper.rb
 module Admin::VersionsHelper
   # HTMLを人が読みやすいプレーンテキストへ
-  # - <br>       => 改行
-  # - </p> </li> => 改行（段落/箇条書きの区切り）
-  # - <li>       => 先頭に中黒（・）
-  # その後 strip_tags で安全にタグ除去
+  # Quill の出力もある程度崩さず読めるように調整
   def textify_html(html)
     s = html.to_s.dup
+
+    # Quill の空白
+    s.gsub!(/&nbsp;/i, " ")
+
+    # <style>, <script> ブロックごと除去
+    s.gsub!(%r{<style[^>]*>.*?</style>}mi, "")
+    s.gsub!(%r{<script[^>]*>.*?</script>}mi, "")
+
+    # 行区切り
     s.gsub!(/<br\s*\/?>/i, "\n")
     s.gsub!(/<\/p\s*>/i, "\n\n")
     s.gsub!(/<\/li\s*>/i, "\n")
     s.gsub!(/<li[^>]*>/i, "・")
+
+    # コードブロック（pre/code）は保つ
+    s.gsub!(/<pre[^>]*><code[^>]*>(.*?)<\/code><\/pre>/mi) { "\n```\n#{$1}\n```\n" }
+
     s = strip_tags(s)
     s.gsub(/\n{3,}/, "\n\n").strip
   end
 
   # とりあえずの行単位の簡易差分
-  # （厳密なLCSではないが軽量で、どこが増減したかは掴める）
   def simple_line_diff(before_html, after_html)
     before_lines = textify_html(before_html).split(/\r?\n/)
     after_lines  = textify_html(after_html).split(/\r?\n/)
@@ -27,5 +36,62 @@ module Admin::VersionsHelper
       before_lines:,
       after_lines:
     }
+  end
+
+  # ===== 表示ラベル =====
+  def label_for_item_type(type)
+    case type.to_s
+    when "BookSection"  then "テキスト"
+    when "QuizQuestion" then "クイズ"
+    else type.to_s
+    end
+  end
+
+  def label_for_column(col)
+    case col.to_s
+    when "updated_at"      then "更新日時"
+    when "lock_version"    then "ロックバージョン"
+    when "content"         then "content（本文）"
+    when "quiz_section_id" then "quiz_section_id（相互リンク）"
+    when "question"        then "問題文"
+    when "explanation"     then "解説"
+    when "choice1"         then "選択肢1"
+    when "choice2"         then "選択肢2"
+    when "choice3"         then "選択肢3"
+    when "choice4"         then "選択肢4"
+    when "correct_choice"  then "正解(1..4)"
+    else col.to_s
+    end
+  end
+
+  # ===== 操作者のユーザー情報 =====
+  def actor_for(version)
+    uid = version.whodunnit.to_s
+    return nil if uid.blank? || uid !~ /\A\d+\z/
+    User.find_by(id: uid.to_i)
+  end
+
+  def actor_badge(version)
+    if (u = actor_for(version))
+      %(ID: #{u.id} / #{ERB::Util.h u.name} / #{ERB::Util.h u.email})
+    else
+      ERB::Util.h(version.whodunnit.presence || "-")
+    end
+  end
+
+  # ===== 「編集されたページ」への遷移先 =====
+  # 存在しない場合は nil を返す（ビュー側で非表示）
+  def admin_edit_path_for(version)
+    id = version.item_id
+    case version.item_type
+    when "BookSection"
+      Rails.application.routes.url_helpers.edit_admin_book_section_path(id)
+    when "QuizQuestion"
+      Rails.application.routes.url_helpers.edit_admin_quiz_question_path(id)
+    else
+      nil
+    end
+  rescue StandardError
+    nil
   end
 end

--- a/app/helpers/rich_text_helper.rb
+++ b/app/helpers/rich_text_helper.rb
@@ -1,0 +1,8 @@
+# app/helpers/rich_text_helper.rb
+module RichTextHelper
+  # ビューからはこれ一発でOK
+  # 例: <%= rich_html(@question.explanation) %>
+  def rich_html(html)
+    RichTextSanitizer.call(html)
+  end
+end

--- a/app/helpers/sections_helper.rb
+++ b/app/helpers/sections_helper.rb
@@ -1,13 +1,7 @@
+# app/helpers/sections_helper.rb
 module SectionsHelper
   # BookSection の本文を安全に表示（表示側の二重防御）
-  # 必要なタグ/属性は用途に応じて調整
   def render_section_content(section)
-    allowed_tags  = %w[
-      p pre code h1 h2 h3 h4 h5 h6 b i u strong em a ul ol li br blockquote span div img hr
-    ]
-    # 画像表示に必要な属性を許可（最小限）
-    allowed_attrs = %w[href class rel target src alt loading width height style]
-
-    sanitize(section.content.to_s, tags: allowed_tags, attributes: allowed_attrs)
+    RichTextSanitizer.call(section.content)
   end
 end

--- a/app/javascript/controllers/code_highlight_controller.js
+++ b/app/javascript/controllers/code_highlight_controller.js
@@ -1,0 +1,48 @@
+// app/javascript/controllers/code_highlight_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * - window.hljs（UMD）を利用
+ * - Quill の <pre class="ql-syntax"> など、<code> を内包しないブロックも
+ *   自動で <code> ラップしてからハイライト
+ */
+export default class extends Controller {
+  connect () {
+    // hljs がまだ読み込まれていない場合に備えてポーリング
+    this._tryHighlight(0)
+  }
+
+  _tryHighlight (retry) {
+    const hljs = window.hljs
+    if (!hljs || !hljs.highlightElement) {
+      if (retry < 40) { // 最大 ~2秒（50ms * 40）
+        setTimeout(() => this._tryHighlight(retry + 1), 50)
+      }
+      return
+    }
+    this._highlightAll(hljs)
+  }
+
+  _highlightAll (hljs) {
+    // 1) Quill の <pre class="ql-syntax"> など、<code> を含まない pre を先に <code> で包む
+    const pres = this.element.querySelectorAll(".content-body pre, pre")
+    pres.forEach(pre => {
+      if (!pre.querySelector("code")) {
+        const code = document.createElement("code")
+        // pre のテキストを code に移す（HTML を解釈しない）
+        code.textContent = pre.textContent
+        // 既存内容クリアして code を追加
+        pre.textContent = ""
+        pre.appendChild(code)
+      }
+    })
+
+    // 2) すべての <pre><code> をハイライト
+    const blocks = this.element.querySelectorAll("pre code, .content-body pre code")
+    blocks.forEach(el => {
+      if (!el.classList.contains("hljs")) {
+        try { hljs.highlightElement(el) } catch (_) {}
+      }
+    })
+  }
+}

--- a/app/javascript/controllers/code_view_controller.js
+++ b/app/javascript/controllers/code_view_controller.js
@@ -45,6 +45,15 @@ export default class extends Controller {
 
   disconnect () { this.view?.destroy() }
 
+  // === public: 外部からコードを差し替える用 ===
+  set (value) {
+    const text = value ?? ""
+    this.fieldTarget.value = text
+    if (this.view) {
+      this.view.dispatch({ changes: { from: 0, to: this.view.state.doc.length, insert: text } })
+    }
+  }
+
   // ---- private ----
   #applyContainerTheme () {
     const el = this.mountTarget

--- a/app/javascript/controllers/quill_field_controller.js
+++ b/app/javascript/controllers/quill_field_controller.js
@@ -1,0 +1,122 @@
+// app/javascript/controllers/quill_field_controller.js
+import { Controller } from "@hotwired/stimulus"
+import { DirectUpload } from "@rails/activestorage"
+
+// data-controller="quill-field"
+// data-quill-field-max-length-value="2000" などを想定
+// targets: editor(表示用div), input(hidden)
+export default class extends Controller {
+  static targets = ["editor", "input"]
+  static values  = { placeholder: String, maxLength: Number }
+
+  connect() {
+    if (!window.Quill || !this.hasEditorTarget || !this.hasInputTarget) return
+
+    // Divider(<hr>) を一度だけ登録
+    if (!window.__QL_DIVIDER_REGISTERED__) {
+      const BlockEmbed = window.Quill.import("blots/block/embed")
+      class Divider extends BlockEmbed {
+        static blotName = "divider"
+        static tagName  = "hr"
+      }
+      window.Quill.register(Divider, true)
+      window.__QL_DIVIDER_REGISTERED__ = true
+    }
+
+    // Quill 初期化
+    this.quill = new Quill(this.editorTarget, {
+      theme: "snow",
+      placeholder: this.placeholderValue || "本文を入力…",
+      modules: {
+        toolbar: [
+          [{ header: [1,2,3,false] }],
+          ["bold", "italic", "underline"],
+          [{ list: "ordered" }, { list: "bullet" }],
+          [{ color: [] }, { background: [] }],
+          ["divider"],
+          ["link", "blockquote", "code-block", "image", "clean"]
+        ]
+      }
+    })
+
+    // ツールバー拡張
+    const toolbar = this.quill.getModule("toolbar")
+    toolbar.addHandler("image",   () => this.handleImage())
+    toolbar.addHandler("divider", () => this.handleDivider())
+
+    // Divider ボタンの見た目を少し整える
+    const btn = this.element.querySelector(".ql-toolbar button.ql-divider")
+    if (btn && !btn.innerHTML.trim()) {
+      btn.innerHTML = "—"
+      btn.style.fontWeight = "700"
+      btn.title = "横線を挿入"
+    }
+
+    // 既存 HTML を流し込み（編集時）
+    if (this.inputTarget.value) {
+      this.editorTarget.querySelector(".ql-editor").innerHTML = this.inputTarget.value
+    }
+
+    // 入力と hidden 同期 & 2000 文字制限
+    this.quill.on("text-change", (delta, oldDelta, source) => {
+      // HTML を hidden へ
+      this.inputTarget.value = this.editorTarget.querySelector(".ql-editor").innerHTML
+
+      // 文字数（改行含むテキスト長）を制限
+      if (this.hasMaxLengthValue && source === "user") {
+        const textLen = this.quill.getText().replace(/\n+$/, "").length
+        if (textLen > this.maxLengthValue) {
+          // 超えたぶんを削除（ざっくり：末尾から差分を戻す）
+          // 直近挿入長を推定して1文字だけ戻す（体感的に十分）
+          const len = textLen - this.maxLengthValue
+          const endIndex = this.quill.getLength()
+          this.quill.deleteText(endIndex - (len + 1), len + 1, "silent")
+          this.inputTarget.value = this.editorTarget.querySelector(".ql-editor").innerHTML
+          this.showToast(`最大 ${this.maxLengthValue} 文字までです`)
+        }
+      }
+    })
+  }
+
+  // <hr> 挿入
+  handleDivider() {
+    const range = this.quill.getSelection(true) || { index: this.quill.getLength() }
+    this.quill.insertEmbed(range.index, "divider", true, "user")
+    this.quill.setSelection(range.index + 1)
+  }
+
+  // 画像アップロード（ActiveStorage 直）
+  handleImage() {
+    const input = document.createElement("input")
+    input.type = "file"
+    input.accept = "image/*"
+    input.click()
+
+    input.onchange = () => {
+      const file = input.files?.[0]
+      if (!file) return
+
+      const upload = new DirectUpload(file, "/rails/active_storage/direct_uploads")
+      upload.create((error, blob) => {
+        if (error) {
+          this.showToast("画像アップロードに失敗しました")
+          return
+        }
+        const url = `/rails/active_storage/blobs/redirect/${blob.signed_id}/${encodeURIComponent(file.name)}`
+        const range = this.quill.getSelection(true) || { index: this.quill.getLength() }
+        this.quill.insertEmbed(range.index, "image", url, "user")
+        this.quill.setSelection(range.index + 1)
+        // hidden 更新
+        this.inputTarget.value = this.editorTarget.querySelector(".ql-editor").innerHTML
+      })
+    }
+  }
+
+  showToast(message) {
+    const div = document.createElement("div")
+    div.innerText = message
+    div.className = "fixed bottom-4 right-4 bg-slate-800 text-white px-3 py-1.5 rounded shadow text-sm"
+    document.body.appendChild(div)
+    setTimeout(() => div.remove(), 1800)
+  }
+}

--- a/app/javascript/controllers/tag_picker_controller.js
+++ b/app/javascript/controllers/tag_picker_controller.js
@@ -1,0 +1,176 @@
+// app/javascript/controllers/tag_picker_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [
+    "hiddenInput",   // <input name="tag_names"> or <input name="tags">
+    "selectedArea",  // 選択済みピル
+    "container",     // モーダル
+    "list",          // 一覧
+    "query",         // 絞り込み入力
+    "newName",       // 新規タグ名
+    "createError",   // 新規作成エラー表示
+  ]
+
+  static values = {
+    fetchUrl: { type: String, default: "/tags/popular.json" },
+    max:      { type: Number, default: 10 },      // assign モード時の最大
+    mode:     { type: String, default: "assign" } // "assign" or "filter"
+  }
+
+  connect() {
+    this.selected = new Map() // key: tag.name, value: tag object
+    this._loaded = false
+    this._syncFromHidden()
+    this.renderSelected()
+    // 初期表示でも水和して数/色を正しくする（モーダルを開かなくても反映）
+    this.fetchAndRender().catch(() => {})
+  }
+
+  // ===== モーダル =====
+  open() {
+    this.containerTarget.classList.remove("hidden")
+    document.body.classList.add("overflow-hidden")
+    if (!this._loaded) this.fetchAndRender().catch(() => {})
+  }
+
+  close() {
+    this.containerTarget.classList.add("hidden")
+    document.body.classList.remove("overflow-hidden")
+  }
+
+  // ===== 取得/描画 =====
+  async fetchAndRender(q = "") {
+    const url = new URL(this.fetchUrlValue, window.location.origin)
+    if (q) url.searchParams.set("q", q)
+
+    const res = await fetch(url.toString(), { headers: { "Accept": "application/json" } })
+    const list = await res.json()
+    this._loaded = true
+    // 水和：取得した一覧で選択済みの色/件数を上書き
+    this._hydrateSelected(list)
+    this.renderList(list)
+    this.renderSelected() // 水和結果をフォーム側にも反映
+  }
+
+  queryInput(e) {
+    const q = e.target.value.trim()
+    this.fetchAndRender(q).catch(() => {})
+  }
+
+  renderList(list) {
+    this.listTarget.innerHTML = ""
+    list.forEach(t => {
+      const btn = document.createElement("button")
+      btn.type = "button"
+      btn.className = "inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs border mr-1 mb-1"
+      btn.style = `color:${t.color}; border-color:${t.color}; background:${this._rgbaBg(t.color, 0.12)}`
+      btn.innerHTML = `${this._escape(t.name)} <span class="text-[11px] text-slate-500">(${t.taggings_count})</span>`
+      btn.addEventListener("click", () => this.toggleTag(t))
+      this.listTarget.appendChild(btn)
+    })
+  }
+
+  // ===== 追加/削除 =====
+  toggleTag(tag) {
+    if (this.selected.has(tag.name)) {
+      this.selected.delete(tag.name)
+    } else {
+      if (this.modeValue === "assign" && this.maxValue && this.selected.size >= this.maxValue) {
+        alert(`タグは最大 ${this.maxValue} 個までです`)
+        return
+      }
+      this.selected.set(tag.name, tag)
+    }
+    this.renderSelected()
+    this._syncHidden()
+  }
+
+  renderSelected() {
+    this.selectedAreaTarget.innerHTML = ""
+    for (const t of this.selected.values()) {
+      const pill = document.createElement("span")
+      pill.className = "inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs border mr-1 mb-1"
+      pill.style = `color:${t.color}; border-color:${t.color}; background:${this._rgbaBg(t.color, 0.12)}`
+      pill.innerHTML = `${this._escape(t.name)} <span class="text-[11px] text-slate-500">(${t.taggings_count ?? 0})</span>`
+
+      const x = document.createElement("button")
+      x.type = "button"
+      x.className = "ml-1 text-slate-500 hover:text-slate-700"
+      x.textContent = "×"
+      x.addEventListener("click", () => { this.selected.delete(t.name); this.renderSelected(); this._syncHidden() })
+
+      pill.appendChild(x)
+      this.selectedAreaTarget.appendChild(pill)
+    }
+  }
+
+  // ===== 新規タグ作成 =====
+  async createTag() {
+    const name = this.newNameTarget.value.trim()
+    this.createErrorTarget.textContent = ""
+    if (!name) return
+
+    try {
+      const token = document.querySelector('meta[name="csrf-token"]')?.content
+      const res = await fetch("/tags", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-CSRF-Token": token },
+        body: JSON.stringify({ tag: { name } })
+      })
+      const t = await res.json()
+      if (!res.ok) throw new Error(t.error || "作成に失敗しました")
+
+      // 作成直後から選択済みに入れる
+      this.selected.set(t.name, t)
+      this.renderSelected()
+      this._syncHidden()
+      this.newNameTarget.value = ""
+
+      // 一覧も更新（未使用も popular に出るようサーバ側を修正済み）
+      this._loaded = false
+      this.fetchAndRender(this.queryTarget?.value?.trim() || "").catch(() => {})
+    } catch (e) {
+      this.createErrorTarget.textContent = e.message
+    }
+  }
+
+  // ===== 内部処理 =====
+  _syncHidden() {
+    const names = [...this.selected.keys()]
+    this.hiddenInputTarget.value = names.join(",")
+  }
+
+  _syncFromHidden() {
+    const raw = this.hiddenInputTarget.value || ""
+    raw.split(",").map(s => s.trim()).filter(Boolean).forEach(n => {
+      if (!this.selected.has(n)) {
+        // 一旦プレースホルダ（後で fetch で水和）
+        this.selected.set(n, { name: n, color: "#6B7280", taggings_count: 0 })
+      }
+    })
+  }
+
+  _hydrateSelected(list) {
+    const byName = new Map(list.map(t => [t.name, t]))
+    for (const name of this.selected.keys()) {
+      const hit = byName.get(name)
+      if (hit) this.selected.set(name, hit)
+    }
+  }
+
+  _escape(s) {
+    const div = document.createElement("div")
+    div.textContent = s
+    return div.innerHTML
+  }
+
+  _rgbaBg(hex, a = 0.12) {
+    if (!hex) return `rgba(107,114,128,${a})`
+    const h = hex.replace("#","")
+    const r = parseInt(h.slice(0,2), 16)
+    const g = parseInt(h.slice(2,4), 16)
+    const b = parseInt(h.slice(4,6), 16)
+    return `rgba(${r},${g},${b},${a})`
+  }
+}

--- a/app/jobs/unused_tag_cleanup_job.rb
+++ b/app/jobs/unused_tag_cleanup_job.rb
@@ -1,0 +1,9 @@
+# app/jobs/unused_tag_cleanup_job.rb
+class UnusedTagCleanupJob < ApplicationJob
+  queue_as :default
+
+  # 既定: 10日
+  def perform(days: 10)
+    Tag.cleanup_unused!(older_than: days.to_i.days)
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,14 +2,17 @@
 class Book < ApplicationRecord
   has_many :book_sections, -> { order(:position) }, dependent: :destroy
 
+  # タイトル100 / 説明1000 / 並び順は 1..9999 かつ一意
   validates :title,       presence: true, length: { maximum: 100 }
-  validates :description, presence: true, length: { maximum: 500 }
-
-  # 並び順
+  validates :description, presence: true, length: { maximum: 1000 }
   validates :position,
            presence: true,
-           numericality: { only_integer: true, greater_than: 0 },
-           uniqueness: true   # 重複時にエラー表示（DBのuniqueと二重で守る）
+           numericality: {
+             only_integer: true,
+             greater_than: 0,
+             less_than_or_equal_to: 9_999
+           },
+           uniqueness: true
 
   before_validation :set_default_position, on: :create
 

--- a/app/models/book_section.rb
+++ b/app/models/book_section.rb
@@ -2,13 +2,22 @@
 class BookSection < ApplicationRecord
   has_paper_trail
   belongs_to :book, counter_cache: true, touch: true
+  belongs_to :quiz_section, optional: true
   has_many_attached :images
 
-  validates :heading,  presence: true, length: { maximum: 100 }
-  validates :content,  presence: true
-  validates :position, presence: true,
-                       numericality: { only_integer: true, greater_than_or_equal_to: 0 },
-                       uniqueness: { scope: :book_id }
+  # 見出し50 / 本文3万文字 / 表示順 0..9999（0許容：目次など）/ 画像は25枚まで
+  validates :heading,  presence: true, length: { maximum: 50 }
+  validates :content,  presence: true, length: { maximum: 30_000 }
+  validates :position,
+           presence: true,
+           numericality: {
+             only_integer: true,
+             greater_than_or_equal_to: 0,
+             less_than_or_equal_to: 9_999
+           },
+           uniqueness: { scope: :book_id }
+
+  validate :image_count_within_limit
 
   # =======================
   # スコープ
@@ -31,6 +40,15 @@ class BookSection < ApplicationRecord
   # 編集権限チェック
   # =======================
   def editable_attributes
-    %i[content] # 画像は本文内のsigned_idをattachする既存仕組みで取り込み
+    %i[content]
+  end
+
+  private
+
+  def image_count_within_limit
+    return unless images.attached?
+    if images.attachments.size > 25
+      errors.add(:images, I18n.t!("errors.messages.too_many_images", max: 25))
+    end
   end
 end

--- a/app/models/pre_code.rb
+++ b/app/models/pre_code.rb
@@ -13,13 +13,13 @@ class PreCode < ApplicationRecord
   validates :title,
             presence: true,
             length: { maximum: 50 },
-            format: { without: /\A\s*\z/, message: "を空白だけにはできません" }
+            format: { without: /\A\s*\z/, message: I18n.t!("errors.messages.blank_only") }
 
-  validates :description, length: { maximum: 2000 }, allow_blank: true
-  validates :body, presence: true
-  validates :hint,        length: { maximum: 1000 }, allow_blank: true
-  validates :answer,      length: { maximum: 2000 }, allow_blank: true
-  validates :answer_code, length: { maximum: 2000 }, allow_blank: true
+  validates :description, length: { maximum: 2_000 }
+  validates :body,        presence: true, length: { maximum: 5_000 }
+  validates :hint,        length: { maximum: 1_000 }, allow_blank: true
+  validates :answer,      length: { maximum: 2_000 }, allow_blank: true
+  validates :answer_code, length: { maximum: 2_000 }, allow_blank: true
 
   # Quiz モードのときだけ answer を必須にする
   validates :answer, presence: true, if: :quiz_mode?

--- a/app/models/pre_code_tagging.rb
+++ b/app/models/pre_code_tagging.rb
@@ -4,4 +4,15 @@ class PreCodeTagging < ApplicationRecord
   belongs_to :tag, counter_cache: :taggings_count
 
   validates :pre_code_id, uniqueness: { scope: :tag_id }
+
+  # counter_cache 更新が走った“後”で zero_since を整合
+  after_commit :refresh_tag_zero_since!, on: [ :create, :destroy ]
+
+  private
+
+  def refresh_tag_zero_since!
+    # リロードして最新の taggings_count を見てから更新
+    tag.reload
+    tag.refresh_zero_since!
+  end
 end

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -3,10 +3,15 @@ class Quiz < ApplicationRecord
   has_many :quiz_sections, -> { order(:position) }, dependent: :destroy
   has_many :quiz_questions, dependent: :destroy
 
-  validates :title, presence: true, length: { maximum: 100 }
-  validates :description, presence: true, length: { maximum: 500 }
-  validates :position, presence: true,
-                       numericality: { only_integer: true, greater_than: 0 }
+  validates :title,       presence: true, length: { maximum: 100 }
+  validates :description, presence: true, length: { maximum: 1000 }
+  validates :position,
+           presence: true,
+           numericality: {
+             only_integer: true,
+             greater_than: 0,
+             less_than_or_equal_to: 9_999
+           }
 
   before_validation :set_default_position, on: :create
 

--- a/app/models/quiz_question.rb
+++ b/app/models/quiz_question.rb
@@ -4,16 +4,23 @@ class QuizQuestion < ApplicationRecord
   belongs_to :quiz
   belongs_to :quiz_section
 
-  validates :question, :explanation, presence: true
   with_options presence: true do
-    validates :choice1
-    validates :choice2
-    validates :choice3
-    validates :choice4
+    validates :question,    length: { maximum: 2_000 }
+    validates :explanation, length: { maximum: 2_000 }
+    validates :choice1,     length: { maximum: 100 }
+    validates :choice2,     length: { maximum: 100 }
+    validates :choice3,     length: { maximum: 100 }
+    validates :choice4,     length: { maximum: 100 }
   end
+
   validates :correct_choice, presence: true, inclusion: { in: 1..4 }
-  validates :position, presence: true,
-                       numericality: { only_integer: true, greater_than: 0 }
+  validates :position,
+           presence: true,
+           numericality: {
+             only_integer: true,
+             greater_than: 0,
+             less_than_or_equal_to: 9_999
+           }
 
   # 編集権限チェック
   def editable_attributes

--- a/app/models/quiz_section.rb
+++ b/app/models/quiz_section.rb
@@ -1,15 +1,21 @@
 # app/models/quiz_section.rb
 class QuizSection < ApplicationRecord
   belongs_to :quiz, touch: true
+  belongs_to :book_section, optional: true
   has_many :quiz_questions, -> { order(:position) }, dependent: :destroy
 
-  validates :heading, presence: true, length: { maximum: 100 }
-  validates :position, presence: true,
-                       numericality: { only_integer: true, greater_than: 0 }
+  validates :heading,  presence: true, length: { maximum: 100 }
+  validates :position,
+           presence: true,
+           numericality: {
+             only_integer: true,
+             greater_than: 0,
+             less_than_or_equal_to: 9_999
+           }
   validates :is_free, inclusion: { in: [ true, false ] }
 
-  scope :free,  -> { where(is_free: true)  }
-  scope :paid,  -> { where(is_free: false) }
+  scope :free, -> { where(is_free: true) }
+  scope :paid, -> { where(is_free: false) }
 
   # 前後ナビ（同一 quiz 内）
   def previous = quiz.quiz_sections.where("position < ?", position).order(position: :desc).first

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 # app/models/user.rb
 class User < ApplicationRecord
-  # ---------- アソシエーション ----------
   has_many :pre_codes, dependent: :destroy
   has_many :likes,      dependent: :destroy
   has_many :used_codes, dependent: :destroy
@@ -9,17 +8,11 @@ class User < ApplicationRecord
   has_many :bookmarked_pre_codes, through: :bookmarks, source: :pre_code
   has_many :editor_permissions, dependent: :destroy
 
-  # bcrypt
   has_secure_password validations: false
-
-  # ---------- 正規化 ----------
   before_validation :normalize_email
 
-  # ---------- バリデーション ----------
-  # 共通
   validates :name, presence: true, length: { maximum: 50 }
 
-  # ★ 一意性は「パスワード方式 (= 外部連携なし)」の場合のみチェック
   validates :email,
     presence: true,
     length:  { maximum: 255 },
@@ -27,35 +20,23 @@ class User < ApplicationRecord
     uniqueness: { case_sensitive: false },
     if: :email_uniqueness_required?
 
-  validates :password, presence: true, length: { minimum: 6 }, if: :password_required?
+  validates :password,
+    presence: true,
+    length: { minimum: 6, maximum: 19 },
+    if: :password_required?
 
-  # ---------- スコープ（検索/フィルタ） ----------
-  # 部分一致（大/小文字・全角半角の差を吸収するため、ここでは downcase のみ。
-  # さらに高度な正規化が必要なら unaccent や独自正規化を検討）
   scope :search, ->(q) {
     if q.present?
       where("LOWER(name) LIKE :q OR LOWER(email) LIKE :q", q: "%#{q.to_s.downcase}%")
     end
   }
-
-  # 編集者のみ
   scope :editors, -> { where(editor: true) }
-
-  # 凍結中のみ（banned_at が NULL でない）
   scope :banned,  -> { where.not(banned_at: nil) }
 
-  # ---------- 管理用インスタンスメソッド ----------
-  # 凍結中か？
-  def banned?
-    banned_at.present?
-  end
+  def banned? = banned_at.present?
 
-  # 編集者フラグのトグル（true/false を切替）
-  def toggle_editor!
-    update!(editor: !editor)
-  end
+  def toggle_editor! = update!(editor: !editor)
 
-  # BAN のトグル（理由は任意。設定→解除をトグル）
   def toggle_ban!(reason = nil)
     if banned?
       update!(banned_at: nil, ban_reason: nil)
@@ -64,7 +45,6 @@ class User < ApplicationRecord
     end
   end
 
-  # ---------- パスワード再設定 ----------
   def generate_reset_token!
     self.reset_password_token   = SecureRandom.urlsafe_base64(32)
     self.reset_password_sent_at = Time.current
@@ -81,8 +61,7 @@ class User < ApplicationRecord
     update!(reset_password_token: nil, reset_password_sent_at: nil)
   end
 
-  # --------- OmniAuth ユーザー作成/取得（authentications 経由） ----------
-  # auth は OmniAuth::AuthHash 想定
+  # OmniAuth ユーザー作成/取得
   def self.find_or_create_from_omniauth(auth)
     authentication = Authentication.find_or_initialize_by(
       provider: auth.provider, uid: auth.uid
@@ -95,7 +74,8 @@ class User < ApplicationRecord
     user.name  ||= auth.dig(:info, :name).presence ||
                    auth.dig(:info, :nickname).presence || "User"
     user.email ||= auth.dig(:info, :email)
-    user.password = SecureRandom.hex(16) if user.password_digest.blank?
+    # ★ 16 文字に統一（上限 19）
+    user.password = SecureRandom.alphanumeric(16) if user.password_digest.blank?
     user.save!
 
     if authentication.user_id != user.id
@@ -106,24 +86,13 @@ class User < ApplicationRecord
     user
   end
 
-  # 外部連携が無い (= authentications が空) ユーザーはパスワード方式を使う
-  def uses_password?
-    authentications.blank?
-  end
+  def self.new_remember_token = SecureRandom.urlsafe_base64(32)
 
-  # ===== Remember me =====
-  # 乱数トークンを生成して返す（プレーン）
-  def self.new_remember_token
-    SecureRandom.urlsafe_base64(32)
-  end
-
-  # 与えられた文字列をBCryptダイジェスト化
   def self.digest(str)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
     BCrypt::Password.create(str, cost: cost)
   end
 
-  # 発行：digest保存 + 発行時刻
   def remember!
     token = User.new_remember_token
     update_columns(
@@ -134,79 +103,49 @@ class User < ApplicationRecord
     token
   end
 
-  # 検証：プレーントークンがdigestと一致するか
   def authenticated_remember?(token)
     return false if remember_digest.blank?
     BCrypt::Password.new(remember_digest).is_password?(token)
   end
 
-  # 失効（この端末 or 全端末）
-  def forget!
-    update_columns(remember_digest: nil, remember_created_at: nil, updated_at: Time.current)
-  end
+  def forget! = update_columns(remember_digest: nil, remember_created_at: nil, updated_at: Time.current)
 
-  # パスワード更新時：全端末強制失効（ProfilesController から呼ぶ想定）
-  def revoke_all_remember!
-    forget!
-  end
+  def revoke_all_remember! = forget!
 
-  # Rememberの有効期限（30日）
   def remember_expired?(ttl: 30.days)
     remember_created_at.blank? || remember_created_at < ttl.ago
   end
 
-  # ---------- ブックマーク設定 ----------
-  # その PreCode をブックマーク済みか？
-  def bookmarked?(pre_code)
-    bookmarks.exists?(pre_code_id: pre_code.id)
-  end
+  def bookmarked?(pre_code) = bookmarks.exists?(pre_code_id: pre_code.id)
 
-  # その PreCode のブックマークオブジェクトを返す（なければ nil）
-  def bookmark_for(pre_code)
-    bookmarks.find_by(pre_code_id: pre_code.id)
-  end
+  def bookmark_for(pre_code) = bookmarks.find_by(pre_code_id: pre_code.id)
 
-  # ---------- 共同編集の認可 ----------
-  # 管理者 or editor フラグ保持者は全ページ編集可
-  # それ以外は editor_permissions に該当があれば該当ページのみ編集可
   def can_edit?(record)
     return false if record.nil?
     return true  if admin?
     return true  if editor?
-
-    EditorPermission.exists?(
-      user_id: id,
-      target_type: record.class.name,
-      target_id: record.id
-    )
+    EditorPermission.exists?(user_id: id, target_type: record.class.name, target_id: record.id)
   end
 
-  # sub_editor 相当か？（admin/editor ではなく、個別権限を持っている）
-  def sub_editor?
-    !admin? && !editor? && editor_permissions.exists?
-  end
+  def sub_editor? = !admin? && !editor? && editor_permissions.exists?
 
-  # 画面表示用の有効ロール（優先順: admin > editor > sub_editor > general）
   def effective_role
-    return :admin       if admin?
-    return :editor      if editor?
-    return :sub_editor  if editor_permissions.exists?
+    return :admin      if admin?
+    return :editor     if editor?
+    return :sub_editor if editor_permissions.exists?
     :general
   end
 
+  # 外部連携が無い (= authentications が空) ユーザーはパスワード方式を使う
+  def uses_password? = authentications.blank?
+
   private
 
-  def normalize_email
-    self.email = email.to_s.strip.downcase.presence
-  end
+  def normalize_email = self.email = email.to_s.strip.downcase.presence
 
-  # 「通常ログイン (= 外部連携なし) で、新規作成 or パスワード入力があるとき」だけ必須
   def password_required?
     uses_password? && (new_record? || password.present?)
   end
 
-  # ★ email 一意性チェックを実行するか
-  def email_uniqueness_required?
-    uses_password?
-  end
+  def email_uniqueness_required? = uses_password?
 end

--- a/app/services/rich_text_sanitizer.rb
+++ b/app/services/rich_text_sanitizer.rb
@@ -1,0 +1,18 @@
+# app/services/rich_text_sanitizer.rb
+# どこからでも呼べる共通サニタイザ（サービスオブジェクト）
+class RichTextSanitizer
+  ALLOWED_TAGS = %w[
+    p pre code h1 h2 h3 h4 h5 h6 b i u strong em a ul ol li br blockquote span div img hr
+  ].freeze
+
+  # img の表示に最低限必要な属性＋基本属性
+  ALLOWED_ATTRS = %w[href class rel target src alt loading width height style].freeze
+
+  def self.call(html)
+    ActionController::Base.helpers.sanitize(
+      html.to_s,
+      tags: ALLOWED_TAGS,
+      attributes: ALLOWED_ATTRS
+    )
+  end
+end

--- a/app/views/admin/book_sections/_form.html.erb
+++ b/app/views/admin/book_sections/_form.html.erb
@@ -37,6 +37,20 @@
       </div>
     </div>
 
+    <!-- ★ 対応クイズ（任意） -->
+    <div class="space-y-2">
+      <%= f.label :quiz_section_id, "対応するクイズセクション（任意）", class: "block font-semibold text-slate-800" %>
+      <% quiz_options = QuizSection
+          .includes(:quiz).order("quizzes.title ASC, quiz_sections.position ASC")
+          .map { |s| ["#{s.quiz.title} / #{s.heading}（#{s.position}）", s.id] } %>
+      <%= f.select :quiz_section_id,
+            options_for_select(quiz_options, @section.quiz_section_id),
+            { include_blank: "未設定（リンクを出さない）" },
+            class: "w-full md:w-[36rem] rounded-md border border-slate-300 bg-white px-3 py-2
+                    shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500" %>
+      <p class="text-xs text-slate-500">※設定すると本文下に「クイズを解く」ボタンが表示されます。</p>
+    </div>
+
     <!-- 本文（Quill 編集用） -->
     <div class="space-y-2">
       <%= f.label :content, class: "block font-semibold text-slate-800" %>

--- a/app/views/admin/editor_permissions/bulk_new.html.erb
+++ b/app/views/admin/editor_permissions/bulk_new.html.erb
@@ -1,4 +1,8 @@
 <!-- app/views/admin/editor_permissions/bulk_new.html.erb -->
+<% breadcrumb :admin_editor_permissions %>
+<% breadcrumb :bulk_new_admin_editor_permissions %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-2xl font-bold mb-6">編集権限を一括付与</h1>
 
 <%= form_with url: bulk_create_admin_editor_permissions_path, method: :post, local: true, class: "space-y-5" do |f| %>

--- a/app/views/admin/editor_permissions/edit.html.erb
+++ b/app/views/admin/editor_permissions/edit.html.erb
@@ -1,3 +1,7 @@
 <!-- app/views/admin/editor_permissions/edit.html.erb -->
+<% breadcrumb :admin_editor_permissions %>
+<% breadcrumb :edit_admin_editor_permission, @editor_permission %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-2xl font-bold mb-6">編集権限を編集</h1>
 <%= render "form" %>

--- a/app/views/admin/editor_permissions/index.html.erb
+++ b/app/views/admin/editor_permissions/index.html.erb
@@ -1,4 +1,7 @@
 <!-- app/views/admin/editor_permissions/index.html.erb -->
+<% breadcrumb :admin_editor_permissions %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-2xl font-bold mb-6">Editor Permissions</h1>
 
 <div class="flex flex-wrap gap-3 mb-4">

--- a/app/views/admin/editor_permissions/new.html.erb
+++ b/app/views/admin/editor_permissions/new.html.erb
@@ -1,3 +1,7 @@
 <!-- app/views/admin/editor_permissions/new.html.erb -->
+<% breadcrumb :admin_editor_permissions %>
+<% breadcrumb :new_admin_editor_permission %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-2xl font-bold mb-6">編集権限を付与</h1>
 <%= render "form" %>

--- a/app/views/admin/editor_permissions/show.html.erb
+++ b/app/views/admin/editor_permissions/show.html.erb
@@ -1,4 +1,8 @@
 <!-- app/views/admin/editor_permissions/show.html.erb -->
+<% breadcrumb :admin_editor_permissions %>
+<% breadcrumb :admin_editor_permission, @editor_permission %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-2xl font-bold mb-6">権限の詳細</h1>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/app/views/admin/pre_codes/edit.html.erb
+++ b/app/views/admin/pre_codes/edit.html.erb
@@ -1,3 +1,7 @@
+<% breadcrumb :admin_pre_codes %>
+<% breadcrumb :admin_pre_code_edit, @pre_code %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "PreCode編集" %>
 <h1 class="text-xl font-semibold mb-4">PreCode編集</h1>
 <%= render "pre_codes/form", pre_code: @pre_code, namespace: :admin %>

--- a/app/views/admin/pre_codes/index.html.erb
+++ b/app/views/admin/pre_codes/index.html.erb
@@ -1,3 +1,6 @@
+<% breadcrumb :admin_pre_codes %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "PreCode管理" %>
 
 <h1 class="text-xl font-semibold text-slate-900 mb-4">PreCode 管理</h1>
@@ -17,33 +20,71 @@
           placeholder: "ユーザー名／メール",
           class: "min-w-[12rem] w-64 rounded-md border ring-1 ring-slate-300 px-3 py-2 text-sm" %>
 
-    <%# --- タグ（複数選択） --- %>
-    <% if defined?(Tag) && PreCode.reflect_on_association(:tags) %>
-      <div class="flex items-end gap-2">
-        <label class="text-xs text-slate-500 mb-2">タグ</label>
-        <%= select_tag :tag_ids,
-              options_from_collection_for_select(
-                Tag.order(:name), :id, :name, Array(params[:tag_ids]).map(&:to_i)
-              ),
-              multiple: true, size: 1,
-              class: "min-w-[14rem] md:w-80 rounded-md border ring-1 ring-slate-300 px-2 py-2 text-sm" %>
+    <%# --- タグ（一般側と同じ“タグピッカー”） --- %>
+    <div class="ml-auto flex items-center gap-2"
+         data-controller="tag-picker"
+         data-tag-picker-fetch-url-value="/tags/popular.json"
+         data-tag-picker-mode-value="filter">
+
+      <label class="text-xs text-slate-500 mb-2">タグ</label>
+
+      <!-- 選択済み（見た目だけ。送信は hidden で） -->
+      <div data-tag-picker-target="selectedArea" class="min-h-[1.75rem]"></div>
+
+      <!-- hidden（タグ名のカンマ区切り）※同じ form 内 -->
+      <input type="hidden" name="tags" value="<%= params[:tags].to_s %>"
+             data-tag-picker-target="hiddenInput">
+
+      <button type="button" class="px-3 py-2 rounded ring-1 ring-slate-300"
+              data-action="tag-picker#open">
+        タグを選ぶ
+      </button>
+
+      <%= select_tag :sort,
+            options_for_select(
+              [["作成日(新しい順)", ""],
+               ["いいね数", "likes"],
+               ["利用数", "used"],
+               ["タイトル昇順", "title"]],
+              params[:sort]
+            ),
+            class: "rounded-md border ring-1 ring-slate-300 px-3 py-2 text-sm" %>
+
+      <%= submit_tag "検索",
+            class: "rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800" %>
+
+      <!-- モーダル（一般側と同じUI：×はHeroicon、閉じるは中央・ホバー赤） -->
+      <div class="hidden fixed inset-0 z-50 grid place-items-center bg-black/40"
+           data-tag-picker-target="container">
+        <div class="relative w-11/12 max-w-2xl rounded-2xl bg-white p-5 shadow-lg text-slate-900">
+          <!-- 右上 × -->
+          <button type="button"
+                  class="absolute right-4 top-4 text-slate-500 hover:text-slate-700"
+                  data-action="tag-picker#close" aria-label="閉じる">
+            <%= heroicon "x-mark", variant: :solid, options: { class: "w-6 h-6" } %>
+          </button>
+
+          <div class="mb-3">
+            <h3 class="font-semibold">タグを選択（検索）</h3>
+          </div>
+
+          <input type="text" placeholder="タグ名で絞り込み"
+                 class="w-full rounded ring-1 ring-slate-300 px-3 py-2 mb-3"
+                 data-tag-picker-target="query"
+                 data-action="input->tag-picker#queryInput">
+
+          <div data-tag-picker-target="list" class="max-h-[50vh] overflow-auto"></div>
+
+          <div class="mt-4 flex justify-center">
+            <button type="button"
+                    class="inline-flex items-center justify-center px-6 py-2 rounded-full ring-1 ring-[#CC0000] text-[#CC0000] bg-white hover:bg-[#CC0000] hover:text-white active:bg-[#FFD6FF] transition-colors"
+                    data-action="tag-picker#close">
+              閉じる
+            </button>
+          </div>
+        </div>
       </div>
-    <% end %>
-
-    <div class="flex-1"></div>
-
-    <%= select_tag :sort,
-          options_for_select(
-            [["作成日(新しい順)", ""],
-             ["いいね数", "likes"],
-             ["利用数", "used"],
-             ["タイトル昇順", "title"]],
-            params[:sort]
-          ),
-          class: "rounded-md border ring-1 ring-slate-300 px-3 py-2 text-sm" %>
-
-    <%= submit_tag "検索",
-          class: "rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800" %>
+    </div>
   </div>
 <% end %>
 
@@ -51,7 +92,7 @@
   <table class="min-w-full divide-y divide-slate-200">
     <thead class="bg-slate-50 text-xs text-slate-600">
       <tr>
-        <th class="px-3 py-2 text-left"><input type="checkbox" disabled></th>
+        <%# チェックボックス列は不要なので削除 %>
         <th class="px-3 py-2 text-left">タイトル</th>
         <th class="px-3 py-2 text-left">説明(100字)</th>
         <% if PreCode.reflect_on_association(:tags) %><th class="px-3 py-2 text-left">タグ</th><% end %>
@@ -65,7 +106,7 @@
     <tbody class="divide-y divide-slate-100 text-sm">
       <% @pre_codes.each do |p| %>
         <tr class="hover:bg-slate-50/60">
-          <td class="px-3 py-2"><input type="checkbox" disabled></td>
+          <%# チェックボックス列削除に伴い先頭TDも削除 %>
           <td class="px-3 py-2 font-medium"><%= p.title %></td>
           <td class="px-3 py-2 text-slate-600"><%= truncate(p.description.to_s, length: 100) %></td>
           <% if PreCode.reflect_on_association(:tags) %>

--- a/app/views/admin/pre_codes/show.html.erb
+++ b/app/views/admin/pre_codes/show.html.erb
@@ -1,3 +1,7 @@
+<% breadcrumb :admin_pre_codes %>
+<% breadcrumb :admin_pre_code, @pre_code %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "PreCode詳細" %>
 
 <div class="mx-auto w-full max-w-3xl space-y-6">

--- a/app/views/admin/quiz_questions/_form.html.erb
+++ b/app/views/admin/quiz_questions/_form.html.erb
@@ -26,9 +26,16 @@
           {}, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
   </div>
 
+  <!-- ▼ 問題文（Quill） -->
   <div>
-    <%= f.label :question, "問題文", class: "block text-sm text-slate-600" %>
-    <%= f.text_area :question, rows: 3, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+    <%= f.label :question, "問題文（最大2000文字）", class: "block text-sm text-slate-600 mb-1" %>
+    <div data-controller="quill-field"
+         data-quill-field-max-length-value="2000"
+         data-quill-field-placeholder-value="問題文を入力…"
+         class="rounded ring-1 ring-slate-300 bg-white">
+      <div data-quill-field-target="editor" class="min-h-[220px] ql-container ql-snow rounded-t"></div>
+      <%= f.hidden_field :question, data: { "quill-field-target": "input" } %>
+    </div>
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -61,9 +68,16 @@
     </div>
   </div>
 
+  <!-- ▼ 解説（Quill） -->
   <div>
-    <%= f.label :explanation, "解説", class: "block text-sm text-slate-600" %>
-    <%= f.text_area :explanation, rows: 4, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+    <%= f.label :explanation, "解説（最大2000文字）", class: "block text-sm text-slate-600 mb-1" %>
+    <div data-controller="quill-field"
+         data-quill-field-max-length-value="2000"
+         data-quill-field-placeholder-value="解説を入力…"
+         class="rounded ring-1 ring-slate-300 bg-white">
+      <div data-quill-field-target="editor" class="min-h-[220px] ql-container ql-snow rounded-t"></div>
+      <%= f.hidden_field :explanation, data: { "quill-field-target": "input" } %>
+    </div>
   </div>
 
   <div>

--- a/app/views/admin/quiz_questions/edit.html.erb
+++ b/app/views/admin/quiz_questions/edit.html.erb
@@ -1,2 +1,6 @@
+<% breadcrumb :admin_quiz_questions %>
+<% breadcrumb :admin_quiz_question_edit, @quiz_question %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-xl font-bold mb-4">Quiz 問題を編集</h1>
 <%= render "form" %>

--- a/app/views/admin/quiz_questions/index.html.erb
+++ b/app/views/admin/quiz_questions/index.html.erb
@@ -1,3 +1,6 @@
+<% breadcrumb :admin_quiz_questions %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-xl font-bold mb-4">Quiz Questions</h1>
 
 <div class="mb-3">

--- a/app/views/admin/quiz_questions/new.html.erb
+++ b/app/views/admin/quiz_questions/new.html.erb
@@ -1,2 +1,6 @@
+<% breadcrumb :admin_quiz_questions %>
+<% breadcrumb :admin_quiz_question_new %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-xl font-bold mb-4">Quiz 問題を作成</h1>
 <%= render "form" %>

--- a/app/views/admin/quiz_questions/update.html.erb
+++ b/app/views/admin/quiz_questions/update.html.erb
@@ -1,2 +1,0 @@
-<h1>Admin::QuizQuestions#update</h1>
-<p>Find me in app/views/admin/quiz_questions/update.html.erb</p>

--- a/app/views/admin/quiz_sections/_form.html.erb
+++ b/app/views/admin/quiz_sections/_form.html.erb
@@ -1,45 +1,46 @@
+<!-- app/views/admin/quiz_sections/_form.html.erb -->
 <%= form_with model: @section,
               url: (@section.new_record? ? admin_quiz_sections_path : admin_quiz_section_path(@section)),
-              method: (@section.new_record? ? :post : :patch),
-              local: true,
-              class: "space-y-4" do |f| %>
-  <% if @section.errors.any? %>
-    <div class="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">
-      <p><strong><%= @section.errors.count %></strong> 件のエラーがあります：</p>
-      <ul class="list-disc pl-5 mt-1">
-        <% @section.errors.full_messages.each do |m| %><li><%= m %></li><% end %>
-      </ul>
+              method: (@section.new_record? ? :post : :patch) do |f| %>
+  <div class="grid gap-6">
+    <div>
+      <%= f.label :quiz_id, "クイズ", class: "block font-semibold" %>
+      <%= f.collection_select :quiz_id, Quiz.order(:title), :id, :title,
+            {}, class: "w-80 rounded border px-3 py-2" %>
     </div>
-  <% end %>
 
-  <div>
-    <%= f.label :quiz_id, "Quiz", class: "block text-sm text-slate-600" %>
-    <%= f.collection_select :quiz_id, Quiz.order(:position), :id, :title,
-          {}, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
-  </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div>
+        <%= f.label :position, class: "block font-semibold" %>
+        <%= f.number_field :position, min: 1, class: "w-40 rounded border px-3 py-2" %>
+      </div>
+      <div class="flex items-center gap-2">
+        <%= f.check_box :is_free, class: "h-5 w-5" %>
+        <%= f.label :is_free, "無料公開", class: "font-semibold" %>
+      </div>
+    </div>
 
-  <div>
-    <%= f.label :heading, "見出し", class: "block text-sm text-slate-600" %>
-    <%= f.text_field :heading, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
-  </div>
+    <div>
+      <%= f.label :heading, class: "block font-semibold" %>
+      <%= f.text_field :heading, class: "w-full md:w-[36rem] rounded border px-3 py-2" %>
+    </div>
 
-  <div>
-    <label class="inline-flex items-center gap-2">
-      <%= f.check_box :is_free %>
-      <span>FREE（未ログインでも解ける）</span>
-    </label>
-  </div>
+    <!-- ★ 対応テキスト（任意） -->
+    <div>
+      <%= f.label :book_section_id, "対応するRails Booksセクション（任意）", class: "block font-semibold" %>
+      <% book_options = BookSection
+          .includes(:book).order("books.title ASC, book_sections.position ASC")
+          .map { |s| ["#{s.book.title} / #{s.heading}（#{s.position}）", s.id] } %>
+      <%= f.select :book_section_id,
+            options_for_select(book_options, @section.book_section_id),
+            { include_blank: "未設定（リンクを出さない）" },
+            class: "w-full md:w-[36rem] rounded border px-3 py-2" %>
+      <p class="text-xs text-slate-500">※設定すると結果ページに「Rails Booksへ」ボタンが表示されます。</p>
+    </div>
 
-  <div>
-    <%= f.label :position, "位置", class: "block text-sm text-slate-600" %>
-    <%= f.number_field :position, min: 1, step: 1,
-          class: "w-40 rounded ring-1 ring-slate-300 px-3 py-2" %>
-  </div>
-
-  <div>
-    <%= f.submit (@section.new_record? ? "作成する" : "更新する"),
-          class: "px-4 py-2 rounded bg-slate-900 text-white" %>
-    <%= link_to "一覧に戻る", admin_quiz_sections_path,
-          class: "ml-2 px-4 py-2 rounded ring-1 ring-slate-300" %>
+    <div class="pt-2">
+      <%= f.submit(@section.new_record? ? "作成する" : "更新する",
+            class: "inline-flex items-center rounded bg-slate-900 px-5 py-2.5 text-white hover:bg-slate-800") %>
+    </div>
   </div>
 <% end %>

--- a/app/views/admin/quiz_sections/edit.html.erb
+++ b/app/views/admin/quiz_sections/edit.html.erb
@@ -1,2 +1,6 @@
+<% breadcrumb :admin_quiz_sections %>
+<% breadcrumb :admin_quiz_section_edit, @quiz_section %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-xl font-bold mb-4">Quiz セクションを編集</h1>
 <%= render "form" %>

--- a/app/views/admin/quiz_sections/index.html.erb
+++ b/app/views/admin/quiz_sections/index.html.erb
@@ -1,3 +1,6 @@
+<% breadcrumb :admin_quiz_sections %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-xl font-bold mb-4">Quiz Sections</h1>
 
 <div class="mb-3">

--- a/app/views/admin/quiz_sections/new.html.erb
+++ b/app/views/admin/quiz_sections/new.html.erb
@@ -1,2 +1,6 @@
+<% breadcrumb :admin_quiz_sections %>
+<% breadcrumb :admin_quiz_section_new %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-xl font-bold mb-4">Quiz セクションを作成</h1>
 <%= render "form" %>

--- a/app/views/admin/quizzes/edit.html.erb
+++ b/app/views/admin/quizzes/edit.html.erb
@@ -1,3 +1,7 @@
 <!-- app/views/admin/quizzes/edit.html.erb -->
+<% breadcrumb :admin_quizzes %>
+<% breadcrumb :admin_quiz_edit, @quiz %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-xl font-bold mb-4">Quiz を編集</h1>
 <%= render "form" %>

--- a/app/views/admin/quizzes/index.html.erb
+++ b/app/views/admin/quizzes/index.html.erb
@@ -1,4 +1,7 @@
 <!-- app/views/admin/quizzes/index.html.erb -->
+<% breadcrumb :admin_quizzes %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-xl font-bold mb-4">Quizzes</h1>
 
 <div class="mb-3">

--- a/app/views/admin/quizzes/new.html.erb
+++ b/app/views/admin/quizzes/new.html.erb
@@ -1,3 +1,7 @@
 <!-- app/views/admin/quizzes/new.html.erb -->
+<% breadcrumb :admin_quizzes %>
+<% breadcrumb :admin_quiz_new %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-xl font-bold mb-4">Quiz を作成</h1>
 <%= render "form" %>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -1,4 +1,6 @@
 <%# app/views/admin/tags/index.html.erb %>
+<% breadcrumb :admin_tags %>
+<%= render "shared/breadcrumbs" %>
 
 <h1 class="text-xl font-bold mb-4">Tags</h1>
 
@@ -33,7 +35,7 @@
           <td class="p-2">
             <%# 色スウォッチ + HEX 表示（背景色は直接指定） %>
             <span class="inline-block w-4 h-4 rounded align-middle"
-                  style="background-color: '<%= t.color.presence || '#6B7280' %>'"></span>
+                  style="background-color: '<%= (t.color.presence || '#6B7280') %>'"></span>
             <code class="ml-1 text-xs align-middle"><%= t.color %></code>
           </td>
           <td class="p-2 text-right"><%= t.taggings_count %></td>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,12 +1,16 @@
 <!-- app/views/admin/users/index.html.erb -->
+<% breadcrumb :admin_users %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-xl font-semibold text-slate-900 mb-4">ユーザー管理</h1>
 
 <%= form_with url: admin_users_path, method: :get, local: true, class: "mb-6" do %>
   <div class="flex flex-wrap items-end gap-3">
-    <div class="grow min-w-[220px]">
+    <div class="grow min-w-[260px]">
       <%= text_field_tag :q, params[:q],
-            placeholder: "名前またはメールを検索",
+            placeholder: "ID / 名前 / メールで検索",
             class: "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-900" %>
+      <p class="mt-1 text-xs text-slate-500">※ 数字のみを入れると ID 検索になります</p>
     </div>
 
     <div>
@@ -26,6 +30,7 @@
   <table class="min-w-full divide-y divide-slate-200">
     <thead class="bg-slate-50">
       <tr>
+        <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">ID</th>
         <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">名前</th>
         <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">メール</th>
         <th class="px-4 py-2 text-left text-xs font-semibold text-slate-600">権限</th>
@@ -36,10 +41,11 @@
     <tbody class="divide-y divide-slate-100 text-sm">
       <% @users.each do |u| %>
         <tr class="hover:bg-slate-50/60">
+          <td class="px-4 py-2 font-mono text-slate-700"><%= u.id %></td>
           <td class="px-4 py-2 font-medium text-slate-900"><%= u.name %></td>
           <td class="px-4 py-2 text-slate-700"><%= u.email %></td>
 
-          <!-- 権限バッジ（admin > editor > sub_editor > 一般） -->
+          <!-- 権限バッジ -->
           <td class="px-4 py-2"><%= role_badge_for(u) %></td>
 
           <!-- 凍結/有効バッジ -->

--- a/app/views/admin/versions/index.html.erb
+++ b/app/views/admin/versions/index.html.erb
@@ -1,4 +1,7 @@
 <!-- app/views/admin/versions/index.html.erb -->
+<% breadcrumb :admin_versions %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-2xl font-bold mb-6">変更履歴</h1>
 
 <%= form_with url: admin_versions_path, method: :get, local: true, class: "grid grid-cols-1 md:grid-cols-12 gap-3 items-end mb-5" do %>
@@ -39,10 +42,10 @@
             <input type="checkbox" id="check_all">
           </th>
           <th class="p-2 text-left w-48">日時</th>
-          <th class="p-2 text-left">タイプ</th>
-          <th class="p-2 text-right w-24">ID</th>
+          <th class="p-2 text-left whitespace-nowrap">対象モデル</th>
+          <th class="p-2 text-right w-24">対象ID</th>
           <th class="p-2 text-left w-28">イベント</th>
-          <th class="p-2 text-right w-24">ユーザー</th>
+          <th class="p-2 text-left w-[320px]">ユーザー（ID / 名前 / メール）</th>
           <th class="p-2 w-36"></th>
         </tr>
       </thead>
@@ -53,7 +56,7 @@
               <input type="checkbox" name="version_ids[]" value="<%= v.id %>" class="row-check">
             </td>
             <td class="p-2 whitespace-nowrap"><%= l v.created_at, format: :long %></td>
-            <td class="p-2 font-mono"><%= v.item_type %></td>
+            <td class="p-2 whitespace-nowrap"><%= label_for_item_type(v.item_type) %></td>
             <td class="p-2 text-right"><%= v.item_id %></td>
             <td class="p-2">
               <% badge = case v.event
@@ -64,7 +67,7 @@
               end %>
               <span class="px-2 py-0.5 rounded text-xs <%= badge %>"><%= v.event %></span>
             </td>
-            <td class="p-2 text-right"><%= v.whodunnit.presence || "-" %></td>
+            <td class="p-2"><%= actor_badge(v).html_safe %></td>
             <td class="p-2 text-right whitespace-nowrap">
               <%= link_to "詳細", admin_version_path(v),
                     class: "inline-block rounded px-3 py-1 bg-slate-900 text-white text-xs" %>

--- a/app/views/admin/versions/show.html.erb
+++ b/app/views/admin/versions/show.html.erb
@@ -1,4 +1,8 @@
 <%# ===== Admin: Version Show ===== %>
+<% breadcrumb :admin_versions %>
+<% breadcrumb :admin_version, @version %>
+<%= render "shared/breadcrumbs" %>
+
 <h1 class="text-2xl font-bold mb-6">変更詳細</h1>
 
 <%# ===== メタ情報カード ===== %>
@@ -6,9 +10,9 @@
   <div class="col-span-3 rounded border bg-white">
     <div class="px-4 py-3 border-b font-semibold">対象</div>
     <div class="px-4 py-3 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-      <div class="text-slate-500">Type</div><div class="font-mono"><%= @version.item_type %></div>
-      <div class="text-slate-500">ID</div><div><%= @version.item_id %></div>
-      <div class="text-slate-500">Event</div>
+      <div class="text-slate-500">対象モデル</div><div class=""><%= label_for_item_type(@version.item_type) %></div>
+      <div class="text-slate-500">対象ID</div><div><%= @version.item_id %></div>
+      <div class="text-slate-500">イベント</div>
       <div>
         <% badge = case @version.event
             when "create" then "bg-emerald-100 text-emerald-700"
@@ -18,15 +22,23 @@
           end %>
         <span class="px-2 py-0.5 rounded text-xs <%= badge %>"><%= @version.event %></span>
       </div>
-      <div class="text-slate-500">Who</div><div><%= @version.whodunnit.presence || "-" %></div>
-      <div class="text-slate-500">When</div><div><%= l @version.created_at, format: :long %></div>
+      <div class="text-slate-500">編集者</div>
+      <!-- ★ .html_safe を削除 -->
+      <div><%= actor_badge(@version) %></div>
+      <div class="text-slate-500">変更日時</div><div><%= l @version.created_at, format: :long %></div>
     </div>
   </div>
 
   <div class="col-span-2 rounded border bg-white">
     <div class="px-4 py-3 border-b font-semibold">アクション</div>
     <div class="px-4 py-3 flex flex-wrap gap-3">
-      <%= button_to "この版にロールバック",
+      <% if (to = admin_edit_path_for(@version)) %>
+        <%= link_to "編集されたページに移動",
+              to,
+              class: "rounded bg-white ring-1 ring-slate-300 px-4 py-2 hover:bg-slate-50" %>
+      <% end %>
+
+      <%= button_to "変更前のバージョンにロールバック",
             revert_admin_version_path(@version),
             method: :post,
             data: { turbo_confirm: "この版へ戻します。よろしいですか？" },
@@ -42,26 +54,110 @@
 <%# ===== 変更フィールド ===== %>
 <h2 class="text-xl font-semibold mb-4">変更フィールド</h2>
 
-<% if @version.changeset.present? %>
-  <%# 表示順序: updated_at, lock_version, content, その他 %>
-  <% ordered_keys = %w[updated_at lock_version content] + (@version.changeset.keys.map(&:to_s) - %w[updated_at lock_version content]) %>
+<% raw_keys = (@version.changeset || {}).keys.map(&:to_s) %>
+
+<% if raw_keys.present? || @content_before.present? || @content_after.present? %>
+  <% if @version.item_type == "BookSection" %>
+    <% top_keys   = %w[updated_at lock_version quiz_section_id] & raw_keys %>
+    <% middle     = (raw_keys - (top_keys + ["content"])) %>
+    <% ordered    = top_keys + middle + (raw_keys.include?("content") ? ["content"] : []) %>
+  <% elsif @version.item_type == "QuizQuestion" %>
+    <% top_keys       = %w[updated_at lock_version quiz_section_id] & raw_keys %>
+    <% body_order     = %w[question choice1 choice2 choice3 choice4 correct_choice explanation] & raw_keys %>
+    <% others         = raw_keys - (top_keys + body_order) %>
+    <% ordered        = top_keys + body_order + others %>
+  <% else %>
+    <% ordered = raw_keys %>
+  <% end %>
 
   <div class="space-y-6">
-    <% ordered_keys.each do |col| %>
-      <% before, after = @version.changeset[col] || [] %>
+    <% ordered.each do |col| %>
+      <%# --- BookSection: content は専用UI --- %>
+      <% if col == "content" %>
+        <% before = (@version.changeset&.dig("content", 0) || @content_before) %>
+        <% after  = (@version.changeset&.dig("content", 1) || @content_after)  %>
 
-      <% if col.to_s == "content" %>
+        <% if before.present? || after.present? %>
+          <% text_before = textify_html(before) %>
+          <% text_after  = textify_html(after)  %>
+          <% diff = simple_line_diff(before, after) %>
+
+          <div class="rounded border overflow-hidden bg-white">
+            <div class="px-4 py-3 border-b flex items-center justify-between">
+              <div class="font-semibold">content（本文）</div>
+              <span class="text-xs text-slate-500">改行整形 & 簡易差分</span>
+            </div>
+
+            <div class="px-4 py-4 grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div>
+                <div class="text-xs font-semibold text-slate-500 mb-2">Before</div>
+                <pre class="rounded ring-1 ring-slate-200 bg-slate-50 p-3 max-h-[28rem] overflow-auto leading-relaxed whitespace-pre-wrap"><%= text_before %></pre>
+              </div>
+              <div>
+                <div class="text-xs font-semibold text-slate-500 mb-2">After</div>
+                <pre class="rounded ring-1 ring-slate-200 bg-emerald-50/40 p-3 max-h-[28rem] overflow-auto leading-relaxed whitespace-pre-wrap"><%= text_after %></pre>
+              </div>
+            </div>
+
+            <% if diff[:added].present? || diff[:removed].present? %>
+              <div class="px-4 pb-4">
+                <div class="text-sm font-semibold text-slate-700 mb-2">差分（簡易）</div>
+                <% if diff[:added].present? %>
+                  <div class="mb-2">
+                    <div class="text-xs text-emerald-700 font-semibold mb-1">追加された行</div>
+                    <ul class="text-sm list-disc pl-5">
+                      <% diff[:added].each do |line| %>
+                        <li class="text-emerald-700">+ <%= line %></li>
+                      <% end %>
+                    </ul>
+                  </div>
+                <% end %>
+                <% if diff[:removed].present? %>
+                  <div>
+                    <div class="text-xs text-rose-700 font-semibold mb-1">削除された行</div>
+                    <ul class="text-sm list-disc pl-5">
+                      <% diff[:removed].each do |line| %>
+                        <li class="text-rose-700">− <%= line %></li>
+                      <% end %>
+                    </ul>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+
+            <details class="px-4 pb-4">
+              <summary class="cursor-pointer text-sm text-slate-600 hover:text-slate-900 select-none">
+                HTMLソースを表示
+              </summary>
+              <div class="mt-3 grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <div>
+                  <div class="text-xs font-semibold text-slate-500 mb-2">Before（HTML）</div>
+                  <pre class="rounded ring-1 ring-slate-200 bg-white p-3 text-xs overflow-auto max-h-[24rem]"><%= before %></pre>
+                </div>
+                <div>
+                  <div class="text-xs font-semibold text-slate-500 mb-2">After（HTML）</div>
+                  <pre class="rounded ring-1 ring-slate-200 bg-white p-3 text-xs overflow-auto max_h-[24rem]"><%= after %></pre>
+                </div>
+              </div>
+            </details>
+          </div>
+        <% end %>
+
+      <%# --- QuizQuestion: question / explanation も専用UIで --- %>
+      <% elsif ["question", "explanation"].include?(col) %>
+        <% before, after = (@version.changeset || {})[col] || [nil, nil] %>
+        <% next if before.blank? && after.blank? %>
+
         <% text_before = textify_html(before) %>
         <% text_after  = textify_html(after)  %>
         <% diff = simple_line_diff(before, after) %>
 
         <div class="rounded border overflow-hidden bg-white">
-          <div class="px-4 py-3 border-b flex items-center justify-between">
-            <div class="font-semibold">content（本文）</div>
+          <div class="px-4 py-3 border-b flex items_center justify-between">
+            <div class="font-semibold"><%= label_for_column(col) %></div>
             <span class="text-xs text-slate-500">改行整形 & 簡易差分</span>
           </div>
 
-          <%# 読みやすい本文（改行反映） %>
           <div class="px-4 py-4 grid grid-cols-1 lg:grid-cols-2 gap-6">
             <div>
               <div class="text-xs font-semibold text-slate-500 mb-2">Before</div>
@@ -73,7 +169,6 @@
             </div>
           </div>
 
-          <%# 簡易差分（行単位） %>
           <% if diff[:added].present? || diff[:removed].present? %>
             <div class="px-4 pb-4">
               <div class="text-sm font-semibold text-slate-700 mb-2">差分（簡易）</div>
@@ -100,7 +195,6 @@
             </div>
           <% end %>
 
-          <%# 必要な時だけHTMLソースを開く %>
           <details class="px-4 pb-4">
             <summary class="cursor-pointer text-sm text-slate-600 hover:text-slate-900 select-none">
               HTMLソースを表示
@@ -118,9 +212,11 @@
           </details>
         </div>
 
+      <%# --- その他のフィールドは汎用UI --- %>
       <% else %>
+        <% before, after = (@version.changeset || {})[col] || [nil, nil] %>
         <div class="rounded border overflow-hidden bg-white">
-          <div class="px-4 py-3 border-b font-semibold"><%= col %></div>
+          <div class="px-4 py-3 border-b font-semibold"><%= label_for_column(col) %></div>
           <div class="px-4 py-4 grid grid-cols-1 lg:grid-cols-2 gap-6">
             <div>
               <div class="text-xs font-semibold text-slate-500 mb-2">Before</div>

--- a/app/views/book_sections/edit.html.erb
+++ b/app/views/book_sections/edit.html.erb
@@ -1,4 +1,9 @@
 <!-- app/views/book_sections/edit.html.erb -->
+<% breadcrumb :books %>
+<% breadcrumb :book, @book %>
+<% breadcrumb :book_section_edit, @book, @section %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "セクション編集" %>
 <h1 class="text-xl font-semibold mb-4"><%= @book.title %> / <%= @section.heading %> を編集</h1>
 

--- a/app/views/book_sections/show.html.erb
+++ b/app/views/book_sections/show.html.erb
@@ -3,7 +3,7 @@
 <% breadcrumb :book_section, @book, @section %>
 <%= render "shared/breadcrumbs" %>
 
-<div class="mx-auto w-full max-w-3xl px-4 md:px-6 lg:px-8">
+<div class="mx-auto w-full max-w-3xl px-4 md:px-6 lg:px-8" data-controller="code-highlight">
   <nav class="mb-6 text-sm">
     <%= link_to "← #{@book.title} に戻る", book_path(@book), class: "text-slate-600 hover:underline" %>
   </nav>
@@ -20,9 +20,40 @@
     <%= @section.heading %>
   </h1>
 
+  <!-- ★ ここがハイライト対象（content-body） -->
   <article class="content-body prose break-all md:break-words">
     <%= render_section_content(@section) %>
   </article>
+
+  <!-- ===== アウトプットシェア ===== -->
+  <div class="mt-12 text-center space-y-3"
+       data-controller="share"
+       data-share-url-value="<%= books_url %>">
+
+    <h1 class="text-lg font-semibold">次の章に行く前に...</h1>
+    <p class="text-slate-700 font-medium">
+      この章で学んだことを、Xでアウトプットしてみましょう ✨
+    </p>
+
+    <button type="button"
+            data-action="share#openTwitter"
+            data-text="<%= "#{@section.heading} を学習しました！ #RailsLearning" %>"
+            class="btn-dark">
+      Xでシェア
+    </button>
+  </div>
+
+  <!-- ===== 学んだらクイズで定着！ ===== -->
+  <% if @section.quiz_section.present? %>
+    <div class="mt-10 p-5 rounded-xl ring-1 ring-slate-200 bg-white">
+      <p class="text-lg font-semibold mb-2">この章で学んだ知識を覚えよう！</p>
+      <p class="text-slate-600 mb-4">対応するクイズに挑戦して理解を定着させましょう。</p>
+
+      <%= link_to "クイズを解く",
+            quiz_section_path(@section.quiz_section.quiz, @section.quiz_section),
+            class: "inline-flex items-center rounded-md bg-[#CC0000] px-5 py-2 text-white hover:bg-[#BB0000]" %>
+    </div>
+  <% end %>
 
   <div class="flex items-center justify-between mt-10 pt-6 border-t">
     <div>

--- a/app/views/editor/index.html.erb
+++ b/app/views/editor/index.html.erb
@@ -1,14 +1,10 @@
 <%# app/views/editor/index.html.erb %>
 
-<%# パンくず & タイトル %>
 <% breadcrumb :editor %>
 <%= render "shared/breadcrumbs" %>
 <% content_for :title, "コードエディタ" %>
-
-<%# このページはレイアウト側のコンテナをフル幅にする %>
 <% content_for :page_container_class, "w-full px-2 md:px-4 lg:px-8 py-6" %>
 
-<%# CodeMirror の背景は“コンテナ色を透過”させる %>
 <style>
   .cm-editor, .cm-scroller { background: transparent !important; }
 </style>
@@ -16,31 +12,75 @@
 <div class="w-full space-y-6 bg-white" data-controller="editor loading">
   <h1 class="text-2xl font-semibold"><%= yield :title %></h1>
 
-  <!-- 入力欄（CodeMirror をここにマウント） -->
+  <!-- ===== 上部：タイトル／問題文／ヒント ===== -->
+  <section data-editor-target="quizPanelTop" class="hidden space-y-4 mt-2">
+    <div>
+      <h3 class="text-sm font-semibold text-slate-500">タイトル</h3>
+      <div class="mt-1 rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3"
+           data-editor-target="quizTitle"></div>
+    </div>
+
+    <div>
+      <h3 class="text-sm font-semibold text-slate-500">問題文</h3>
+      <div class="mt-1 rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3"
+           data-editor-target="quizDesc"></div>
+    </div>
+
+    <div data-controller="reveal" class="space-y-2">
+      <div class="flex items-baseline justify-between">
+        <h3 class="text-sm font-semibold text-slate-500">ヒント</h3>
+        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+                data-reveal-target="button" data-action="reveal#toggle">表示する</button>
+      </div>
+      <div class="hidden rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3"
+           data-reveal-target="content" data-editor-target="quizHint"></div>
+    </div>
+  </section>
+
+  <!-- ===== CodeMirror（入力欄） ===== -->
   <div data-editor-target="mount"
        class="w-full min-h-[60vh] ring-1 ring-slate-300 overflow-hidden -mt-3">
   </div>
 
-  <!-- 左側：初期データ選択 ＆ テーマ切替（スマホ時は縦積み） -->
+  <!-- ===== 左：初期データ / 右：テーマ切替＆実行 ===== -->
   <div class="flex flex-col md:flex-row md:items-center gap-2 -mt-3">
-    <!-- セレクト：スマホは幅いっぱい、ラベルはスマホで非表示 -->
     <div class="flex items-center gap-2 w-full md:w-auto">
       <label class="text-sm hidden md:inline" for="precode-select">初期データ</label>
-      <select id="precode-select"
-              data-editor-target="select"
-              data-action="change->editor#changeSelect"
-              class="w-full md:w-80 px-3 py-2 rounded ring-1 ring-slate-300">
-        <option value="">(選択)</option>
-        <% @my_pre_codes.each do |pc| %>
-          <option value="<%= pc.id %>">[自分] <%= pc.title %></option>
-        <% end %>
-        <% @popular_public.each do |pc| %>
-          <option value="<%= pc.id %>">[人気] <%= pc.title %></option>
-        <% end %>
-      </select>
+
+      <% if logged_in? %>
+        <select id="precode-select"
+                data-editor-target="select"
+                data-action="change->editor#changeSelect"
+                class="w-full md:w-[28rem] px-3 py-2 rounded ring-1 ring-slate-300">
+          <option value="">(選択)</option>
+
+          <% if @own_pre_codes.exists? %>
+            <optgroup label="自分のデータ">
+              <% @own_pre_codes.each do |pc| %>
+                <% mode = (pc.answer.present? || pc.answer_code.present?) ? "問題" : "通常" %>
+                <option value="<%= pc.id %>">[<%= mode %>] <%= pc.title %></option>
+              <% end %>
+            </optgroup>
+          <% end %>
+
+          <% if @bookmarked_pre_codes.exists? %>
+            <optgroup label="ブックマーク">
+              <% @bookmarked_pre_codes.each do |pc| %>
+                <% mode = (pc.answer.present? || pc.answer_code.present?) ? "問題" : "通常" %>
+                <option value="<%= pc.id %>">[BM][<%= mode %>] <%= pc.title %></option>
+              <% end %>
+            </optgroup>
+          <% end %>
+        </select>
+      <% else %>
+        <select id="precode-select"
+                class="w-full md:w-[28rem] px-3 py-2 rounded ring-1 ring-slate-300 text-slate-500 cursor-not-allowed"
+                disabled>
+          <option>(この機能はログイン後に利用できます)</option>
+        </select>
+      <% end %>
     </div>
 
-    <!-- ボタン行：スマホはセレクトの下で2つ横並び／PCは右寄せ -->
     <div class="flex gap-2 pt-2 md:pt-0 md:ml-auto">
       <button type="button"
               data-action="editor#toggleTheme"
@@ -48,7 +88,6 @@
         テーマ切替
       </button>
 
-      <!-- 実行ボタン（既存の見た目はそのまま） -->
       <button type="button"
               data-action="editor#run"
               data-editor-target="runButton"
@@ -58,13 +97,42 @@
     </div>
   </div>
 
-  <!-- 出力欄 -->
+  <!-- ===== 実行結果 ===== -->
   <pre data-editor-target="output"
-      class="-mt-3 w-full p-3 rounded-none bg-slate-50 ring-1 ring-slate-200 text-sm whitespace-pre-wrap">
-      <!-- 実行結果がここに表示されます -->
+       class="-mt-3 w-full p-3 rounded-none bg-slate-50 ring-1 ring-slate-200 text-sm whitespace-pre-wrap">
   </pre>
 
-  <!-- JS無効時のフォールバック（そのまま） -->
+  <!-- ===== 下部：解答／解答コード ===== -->
+  <section data-editor-target="quizPanelBottom" class="hidden space-y-4 mt-2">
+    <div data-controller="reveal" class="space-y-2">
+      <div class="flex items-baseline justify-between">
+        <h3 class="text-sm font-semibold text-slate-500">解答</h3>
+        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+                data-reveal-target="button" data-action="reveal#toggle">表示する</button>
+      </div>
+      <div class="hidden rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3"
+           data-reveal-target="content" data-editor-target="quizAnswer"></div>
+    </div>
+
+    <div data-controller="reveal" class="space-y-2">
+      <div class="flex items-baseline justify-between">
+        <h3 class="text-sm font-semibold text-slate-500">解答コード</h3>
+        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+                data-reveal-target="button" data-action="reveal#toggle">表示する</button>
+      </div>
+
+      <div class="hidden" data-reveal-target="content">
+        <style>.cm-editor,.cm-scroller{background:transparent!important}</style>
+        <div data-controller="code-view" data-code-view-theme-value="light"
+             class="rounded-xl ring-1 ring-slate-300 overflow-hidden"
+             data-editor-target="quizAnswerCode">
+          <textarea data-code-view-target="field" class="hidden"></textarea>
+          <div data-code-view-target="mount" class="w-full min-h-[120px]"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <noscript>
     <div class="p-3 rounded bg-amber-50 ring-1 ring-amber-200 text-sm">
       JavaScript を有効にするとエディタを利用できます。

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,15 @@
     <%# Quill CDN %>
     <link href="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.snow.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.min.js"></script>
+
+    <%# highlight.js のダーク系テーマ（GitHub Dark） %>
+    <link href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/highlight.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/languages/ruby.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/languages/bash.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/languages/javascript.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/languages/xml.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/languages/erb.min.js" defer></script>
   </head>
 
   <body class="min-h-screen flex flex-col <%= @body_bg || 'bg-white' %> text-slate-800">

--- a/app/views/pre_codes/_form.html.erb
+++ b/app/views/pre_codes/_form.html.erb
@@ -2,78 +2,106 @@
 <%= render "shared/errors", object: pre_code %>
 
 <%
-  # 管理側から呼ばれたときだけ admin ネームスペースに送る
   admin_namespace = (local_assigns[:namespace] == :admin)
   form_model      = admin_namespace ? [:admin, pre_code] : pre_code
 %>
 
 <%= form_with model: form_model, class: "space-y-6" do |f| %>
-  <div data-controller="precode-mode"
-       data-precode-mode-mode-value="normal"
-       class="space-y-6">
+  <div data-controller="precode-mode" data-precode-mode-mode-value="normal" class="space-y-6">
 
-    <!-- モードの現在値を送る hidden -->
-    <%= f.hidden_field :quiz_mode,
-          value: "false",
-          data: { "precode-mode-target": "modeField" } %>
+    <%= f.hidden_field :quiz_mode, value: "false", data: { "precode-mode-target": "modeField" } %>
 
     <div class="flex items-center justify-end">
-      <button type="button"
-              class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
-              data-precode-mode-target="toggle"
-              data-action="precode-mode#switch">
+      <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+              data-precode-mode-target="toggle" data-action="precode-mode#switch">
         問題モードにする
       </button>
     </div>
 
     <!-- タイトル -->
     <div class="space-y-2">
-      <label class="block text-sm font-semibold text-slate-500"
-             data-precode-mode-target="titleLabel">登録名</label>
-      <%= f.text_field :title,
-            placeholder: "選択肢に表示する名前を入力してください",
+      <label class="block text-sm font-semibold text-slate-500" data-precode-mode-target="titleLabel">登録名</label>
+      <%= f.text_field :title, placeholder: "選択肢に表示する名前を入力してください",
             class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
     </div>
 
-    <!-- タグ -->
-    <div class="space-y-2">
+    <!-- タグ（ピッカー + 新規作成） -->
+    <div class="space-y-2"
+         data-controller="tag-picker"
+         data-tag-picker-fetch-url-value="/tags/popular.json"
+         data-tag-picker-max-value="10"
+         data-tag-picker-mode-value="assign">
       <label class="block text-sm font-semibold text-slate-500">タグ（最大10個）</label>
-      <input id="tag-input" name="tag_names" value="<%= pre_code.tags.map(&:name).join(',') %>"
-             class="w-full rounded-xl ring-1 ring-slate-300 px-3 py-2"
-             placeholder="例: ruby, array, sql"
-             data-controller="tag-token"
-             data-action="input->tag-token#suggest">
-      <div id="tag-suggest" class="text-sm text-slate-500"></div>
+
+      <div data-tag-picker-target="selectedArea" class="min-h-[1.75rem]"></div>
+
+      <input type="hidden" name="tag_names"
+             value="<%= pre_code.tags.map(&:name).join(',') %>"
+             data-tag-picker-target="hiddenInput">
+
+      <div class="flex gap-2 items-center">
+        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+                data-action="tag-picker#open">既存のタグを選ぶ</button>
+
+        <input type="text" placeholder="タグの新規作成"
+               class="rounded-xl ring-1 ring-slate-300 px-3 py-1.5"
+               data-tag-picker-target="newName">
+        <button type="button" class="px-3 py-1 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]"
+                data-action="tag-picker#createTag">作成</button>
+      </div>
+      <p class="text-sm text-red-600" data-tag-picker-target="createError"></p>
+
+      <!-- モーダル -->
+      <div class="hidden fixed inset-0 z-50 grid place-items-center bg-black/40"
+           data-tag-picker-target="container">
+        <div class="relative w-11/12 max-w-2xl rounded-2xl bg-white p-5 shadow-lg text-slate-900">
+          <!-- 右上 ×（Heroicon） -->
+          <button type="button"
+                  class="absolute right-4 top-4 text-slate-500 hover:text-slate-700"
+                  data-action="tag-picker#close" aria-label="閉じる">
+            <%= heroicon "x-mark", variant: :solid, options: { class: "w-6 h-6" } %>
+          </button>
+
+          <div class="mb-3">
+            <h3 class="font-semibold">タグを選択</h3>
+          </div>
+
+          <input type="text" placeholder="タグ名で絞り込み"
+                 class="w-full rounded ring-1 ring-slate-300 px-3 py-2 mb-3"
+                 data-tag-picker-target="query"
+                 data-action="input->tag-picker#queryInput">
+
+          <div data-tag-picker-target="list" class="max-h-[50vh] overflow-auto"></div>
+
+          <!-- 下部中央の閉じるボタン（ホバーで赤背景・白文字） -->
+          <div class="mt-4 flex justify-center">
+            <button type="button"
+                    class="inline-flex items-center justify-center px-6 py-2 rounded-full ring-1 ring-[#CC0000] text-[#CC0000] bg-white hover:bg-[#CC0000] hover:text-white active:bg-[#FFD6FF] transition-colors"
+                    data-action="tag-picker#close">
+              閉じる
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
 
-    <!-- 説明（通常モードの“問題文”相当） -->
+    <!-- 説明 -->
     <div class="space-y-2">
-      <label class="block text-sm font-semibold text-slate-500"
-             data-precode-mode-target="descLabel">コードの説明</label>
-      <%= f.text_area :description, rows: 3,
-            placeholder: "コード内容の説明を簡単に書いてください",
+      <label class="block text-sm font-semibold text-slate-500" data-precode-mode-target="descLabel">コードの説明</label>
+      <%= f.text_area :description, rows: 3, placeholder: "コード内容の説明を簡単に書いてください",
             class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2",
-            data: {
-              controller: "autosize",
-              "autosize-target": "field",
-              "autosize-min-rows-value": 3
-            } %>
+            data: { controller: "autosize", "autosize-target": "field", "autosize-min-rows-value": 3 } %>
     </div>
 
-    <!-- ▼ ヒント（問題モード時のみ表示） -->
+    <!-- ヒント（問題モード） -->
     <div data-precode-mode-target="quizBlock" class="space-y-2 hidden">
       <label class="block text-sm font-semibold text-slate-500">ヒント（任意）</label>
-      <%= f.text_area :hint, rows: 3,
-            placeholder: "ヒント本文（1000文字まで）",
+      <%= f.text_area :hint, rows: 3, placeholder: "ヒント本文（1000文字まで）",
             class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2",
-            data: {
-              controller: "autosize",
-              "autosize-target": "field",
-              "autosize-min-rows-value": 3
-            } %>
+            data: { controller: "autosize", "autosize-target": "field", "autosize-min-rows-value": 3 } %>
     </div>
 
-    <!-- ▼ 登録コード（常に表示） -->
+    <!-- 登録コード -->
     <div class="space-y-2">
       <label class="block text-sm font-semibold text-slate-500">登録コード</label>
       <style>.cm-editor,.cm-scroller{background:transparent!important}</style>
@@ -84,28 +112,19 @@
       </div>
     </div>
 
-    <!-- ▼ 解答（問題モード時のみ表示） -->
+    <!-- 解答（問題モード） -->
     <div data-precode-mode-target="quizBlock" class="space-y-2 hidden">
       <label class="block text-sm font-semibold text-slate-500">解答（必須）</label>
-      <%= f.text_area :answer, rows: 4,
-            placeholder: "解答本文（2000文字まで）",
+      <%= f.text_area :answer, rows: 4, placeholder: "解答本文（2000文字まで）",
             class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2",
-            data: {
-              controller: "autosize",
-              "autosize-target": "field",
-              "autosize-min-rows-value": 4,
-              "precode-mode-target": "answerField"
-            } %>
+            data: { controller: "autosize", "autosize-target": "field", "autosize-min-rows-value": 4, "precode-mode-target": "answerField" } %>
 
       <div class="space-y-2">
         <label class="block text-sm font-semibold text-slate-500">解答用コード（任意）</label>
         <style>.cm-editor,.cm-scroller{background:transparent!important}</style>
         <div data-controller="precode-body" data-precode-body-theme-value="light"
              class="rounded-xl ring-1 ring-slate-300 overflow-hidden">
-          <%= f.text_area :answer_code,
-                data: { "precode-body-target": "field",
-                        "precode-mode-target": "answerCodeField" },
-                class: "hidden" %>
+          <%= f.text_area :answer_code, data: { "precode-body-target": "field", "precode-mode-target": "answerCodeField" }, class: "hidden" %>
           <div data-precode-body-target="mount" class="w-full min-h-[200px]"></div>
         </div>
       </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,4 +1,8 @@
 <!-- app/views/profiles/edit.html.erb -->
+<% breadcrumb :profile %>
+<% breadcrumb :profile_edit %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "プロフィール編集" %>
 <h1 class="text-xl font-semibold mb-4">プロフィール編集</h1>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,4 +1,7 @@
 <!-- app/views/profiles/show.html.erb -->
+<% breadcrumb :profile %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "プロフィール" %>
 
 <div class="mx-auto w-full max-w-2xl space-y-6">

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -1,4 +1,7 @@
 <!-- app/views/quizzes/index.html.erb -->
+<% breadcrumb :quizzes %>
+<%= render "shared/breadcrumbs" %>
+
 <div class="mb-6 text-center">
   <h1 class="text-2xl font-semibold">Quizzes</h1>
   <p class="mt-1 text-sm text-slate-500">~ 教本連動クイズ ~</p>

--- a/app/views/quizzes/sections/empty.html.erb
+++ b/app/views/quizzes/sections/empty.html.erb
@@ -1,4 +1,7 @@
 <!-- app/views/quizzes/sections/empty.html.erb -->
+<% breadcrumb :quiz_empty %>
+<%= render "shared/breadcrumbs" %>
+
 <%# 問題未登録のセクション用 %>
 <% content_for :title, "#{@section.heading} - クイズ" %>
 

--- a/app/views/quizzes/sections/questions/answer.html.erb
+++ b/app/views/quizzes/sections/questions/answer.html.erb
@@ -1,14 +1,19 @@
-<!-- app/views/quizzes/sections/questions/answer.html.erb -->
+<% breadcrumb :quizzes %>
+<% breadcrumb :quiz, @quiz %>
+<% breadcrumb :quiz_section_public, @quiz, @section %>
+<% breadcrumb :quiz_question_answer_page, @quiz, @section, @question %>
+<%= render "shared/breadcrumbs" %>
+
 <% correct = (params[:choice].to_i == @question.correct_choice) %>
-<div class="rounded border p-4 bg-white">
+<div class="rounded border p-4 bg-white" data-controller="code-highlight">
   <p class="<%= correct ? 'text-emerald-700' : 'text-red-700' %> font-semibold">
     <%= correct ? "正解！" : "不正解…" %>
   </p>
   <p class="mt-1 text-sm">正解：<%= @question.public_send("choice#{@question.correct_choice}") %></p>
 
-  <div class="mt-3 p-3 rounded bg-slate-50">
+  <div class="mt-3 p-3 rounded bg-slate-50 content-body">
     <h3 class="font-semibold mb-1">解説</h3>
-    <p><%= simple_format @question.explanation %></p>
+    <div><%= rich_html(@question.explanation) %></div>
   </div>
 
   <div class="flex justify-between mt-4">

--- a/app/views/quizzes/sections/questions/edit.html.erb
+++ b/app/views/quizzes/sections/questions/edit.html.erb
@@ -1,26 +1,58 @@
 <!-- app/views/quizzes/sections/questions/edit.html.erb -->
+<% breadcrumb :quizzes %>
+<% breadcrumb :quiz, @quiz %>
+<% breadcrumb :quiz_section_public, @quiz, @section %>
+<% breadcrumb :quiz_question_edit, @quiz, @section, @question %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "問題を編集" %>
 <h1 class="text-xl font-semibold mb-4"><%= @quiz.title %> / <%= @section.heading %> / Q<%= @question.position %> を編集</h1>
 
-<%= form_with model: @question, url: quiz_section_question_path(@quiz, @section, @question), method: :patch, local: true, class: "space-y-4" do |f| %>
+<%= form_with model: @question,
+              url: quiz_section_question_path(@quiz, @section, @question),
+              method: :patch,
+              local: true,
+              class: "space-y-4" do |f| %>
   <%= f.hidden_field :lock_version %>
+
+  <!-- ▼ 問題文（Quill） -->
   <div>
-    <%= f.label :question, "問題文" %>
-    <%= f.text_area :question, rows: 3, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+    <%= f.label :question, "問題文（最大2000文字）", class: "block text-sm text-slate-600 mb-1" %>
+    <div data-controller="quill-field"
+         data-quill-field-max-length-value="2000"
+         data-quill-field-placeholder-value="問題文を入力…"
+         class="rounded ring-1 ring-slate-300 bg-white">
+      <div data-quill-field-target="editor" class="min-h-[220px] ql-container ql-snow rounded-t"></div>
+      <%= f.hidden_field :question, data: { "quill-field-target": "input" } %>
+    </div>
   </div>
+
   <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
     <div><%= f.label :choice1 %><%= f.text_field :choice1, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %></div>
     <div><%= f.label :choice2 %><%= f.text_field :choice2, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %></div>
     <div><%= f.label :choice3 %><%= f.text_field :choice3, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %></div>
     <div><%= f.label :choice4 %><%= f.text_field :choice4, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %></div>
   </div>
+
   <div class="grid grid-cols-2 gap-3">
-    <div><%= f.label :correct_choice, "正解(1..4)" %><%= f.number_field :correct_choice, min: 1, max: 4, class: "w-24 rounded ring-1 ring-slate-300 px-3 py-2" %></div>
+    <div>
+      <%= f.label :correct_choice, "正解(1..4)" %>
+      <%= f.number_field :correct_choice, min: 1, max: 4, class: "w-24 rounded ring-1 ring-slate-300 px-3 py-2" %>
+    </div>
   </div>
+
+  <!-- ▼ 解説（Quill） -->
   <div>
-    <%= f.label :explanation, "解説" %>
-    <%= f.text_area :explanation, rows: 4, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+    <%= f.label :explanation, "解説（最大2000文字）", class: "block text-sm text-slate-600 mb-1" %>
+    <div data-controller="quill-field"
+         data-quill-field-max-length-value="2000"
+         data-quill-field-placeholder-value="解説を入力…"
+         class="rounded ring-1 ring-slate-300 bg-white">
+      <div data-quill-field-target="editor" class="min-h-[220px] ql-container ql-snow rounded-t"></div>
+      <%= f.hidden_field :explanation, data: { "quill-field-target": "input" } %>
+    </div>
   </div>
+
   <div>
     <%= f.submit "更新する", class: "px-4 py-2 rounded bg-slate-900 text-white" %>
     <%= link_to "戻る", quiz_section_question_path(@quiz, @section, @question), class: "ml-2 underline" %>

--- a/app/views/quizzes/sections/questions/show.html.erb
+++ b/app/views/quizzes/sections/questions/show.html.erb
@@ -1,12 +1,21 @@
-<!-- app/views/quizzes/sections/questions/show.html.erb -->
+<% breadcrumb :quizzes %>
+<% breadcrumb :quiz, @quiz %>
+<% breadcrumb :quiz_section_public, @quiz, @section %>
+<% breadcrumb :quiz_question, @quiz, @section, @question %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "#{@section.heading} - 問題" %>
 <p class="text-sm text-slate-500 mb-2">
   <%= link_to @quiz.title, quiz_path(@quiz) %> / <%= @section.heading %>
 </p>
 
-<div class="rounded border p-4 bg-white">
+<div class="rounded border p-4 bg-white" data-controller="code-highlight">
   <p class="text-slate-500 text-sm mb-1">Q<%= @question.position %></p>
-  <h2 class="text-lg font-semibold mb-3"><%= @question.question %></h2>
+
+  <!-- 問題文（リッチ表示） -->
+  <h2 class="text-lg font-semibold mb-3 content-body">
+    <%= rich_html(@question.question) %>
+  </h2>
 
   <%= form_with url: answer_quiz_section_question_path(@quiz, @section, @question),
                 method: :post,

--- a/app/views/quizzes/sections/result.html.erb
+++ b/app/views/quizzes/sections/result.html.erb
@@ -1,4 +1,9 @@
-<!-- app/views/quizzes/sections/result.html.erb -->
+<!-- app/views/quizzes/sections/result.html.erb（下部に追記 or 置換） -->
+<% breadcrumb :quizzes %>
+<% breadcrumb :quiz, @quiz %>
+<% breadcrumb :quiz_section_result, @quiz, @section %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, "#{@section.heading} - 結果" %>
 <h1 class="text-2xl font-semibold mb-2"><%= @section.heading %> の結果</h1>
 <p class="text-xl mb-4"><span class="font-bold"><%= @correct %></span> / <%= @total %> 正解</p>
@@ -14,7 +19,19 @@
   </button>
 </div>
 
-<div class="flex gap-3">
+<div class="flex gap-3 mt-4">
   <%= link_to "もう一度解く", quiz_section_path(@quiz, @section), class: "px-4 py-2 rounded ring-1 ring-slate-300" %>
   <%= link_to "セクション一覧へ戻る", quiz_path(@quiz), class: "px-4 py-2 rounded ring-1 ring-slate-300" %>
 </div>
+
+<!-- ★ テキストへ戻る導線（任意） -->
+<% if @section.book_section.present? %>
+  <div class="mt-8 p-5 rounded-xl ring-1 ring-slate-200 bg-white">
+    <p class="text-lg font-semibold mb-2">もう一度、テキストを読み直す？</p>
+    <p class="text-slate-600 mb-4">このクイズで出題された内容に対応するテキストへ戻れます。</p>
+
+    <%= link_to "Rails Booksへ",
+          book_section_path(@section.book_section.book, @section.book_section),
+          class: "inline-flex items-center rounded-md bg-slate-900 px-5 py-2 text-white hover:bg-black" %>
+  </div>
+<% end %>

--- a/app/views/quizzes/show.html.erb
+++ b/app/views/quizzes/show.html.erb
@@ -1,4 +1,8 @@
 <!-- app/views/quizzes/show.html.erb -->
+<% breadcrumb :quizzes %>
+<% breadcrumb :quiz, @quiz %>
+<%= render "shared/breadcrumbs" %>
+
 <% content_for :title, @quiz.title %>
 <h1 class="text-3xl font-bold mb-3"><%= @quiz.title %></h1>
 <p class="text-slate-600 mb-6"><%= @quiz.description %></p>

--- a/app/views/shared/_tag_filter.html.erb
+++ b/app/views/shared/_tag_filter.html.erb
@@ -1,22 +1,58 @@
-<%# 目次ページ上部に置くタグ検索フォーム（GET ...?tags= に送る） %>
+<!-- app/views/shared/_tag_filter.html.erb -->
 <% target_url = local_assigns[:url] || pre_codes_path %>
 
-<%= form_with url: target_url,
-              method: :get,
-              local: true,
-              html: { class: "mb-0 ml-auto flex gap-2 items-center" } do %>
-  <input type="text"
-         name="tags"
-         value="<%= params[:tags].to_s %>"
-         placeholder="タグ検索（例: ruby, array）"
-         class="px-3 py-2 rounded ring-1 ring-slate-300 w-64"
-         data-controller="tag-token"
-         data-action="input->tag-token#suggest" />
+<div data-controller="tag-picker"
+     data-tag-picker-fetch-url-value="/tags/popular.json"
+     data-tag-picker-mode-value="filter"
+     class="ml-auto flex items-center gap-2">
 
-  <button type="submit"
-          class="px-3 py-2 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]">
-    検索
-  </button>
-<% end %>
+  <div data-tag-picker-target="selectedArea" class="min-h-[1.75rem]"></div>
 
-<div id="tag-suggest" class="mt-1 text-sm text-slate-500"></div>
+  <%= form_with url: target_url, method: :get, local: true, html: { class: "mb-0 flex gap-2 items-center" } do %>
+    <input type="hidden" name="tags" value="<%= params[:tags].to_s %>"
+           data-tag-picker-target="hiddenInput">
+
+    <button type="button" class="px-3 py-2 rounded ring-1 ring-slate-300"
+            data-action="tag-picker#open">
+      タグを選ぶ
+    </button>
+
+    <button type="submit" class="px-3 py-2 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]">
+      検索
+    </button>
+  <% end %>
+
+  <!-- ピッカーモーダル -->
+  <div class="hidden fixed inset-0 z-50 grid place-items-center bg-black/40"
+       data-tag-picker-target="container">
+    <div class="relative w-11/12 max-w-2xl rounded-2xl bg-white p-5 shadow-lg text-slate-900">
+      <!-- 右上 ×（Heroicon） -->
+      <button type="button"
+              class="absolute right-4 top-4 text-slate-500 hover:text-slate-700"
+              data-action="tag-picker#close" aria-label="閉じる">
+        <%= heroicon "x-mark", variant: :solid, options: { class: "w-6 h-6" } %>
+      </button>
+
+      <div class="mb-3">
+        <h3 class="font-semibold">タグを選択（検索）</h3>
+      </div>
+
+      <input type="text" placeholder="タグ名で絞り込み"
+             class="w-full rounded ring-1 ring-slate-300 px-3 py-2 mb-3"
+             data-tag-picker-target="query"
+             data-action="input->tag-picker#queryInput">
+
+      <div data-tag-picker-target="list" class="max-h-[50vh] overflow-auto"></div>
+
+      <div class="mt-4 flex justify-center">
+        <button type="button"
+                class="inline-flex items-center justify-center px-6 py-2 rounded-full ring-1 ring-[#CC0000] text-[#CC0000] bg-white hover:bg-[#CC0000] hover:text-white active:bg-[#FFD6FF] transition-colors"
+                data-action="tag-picker#close">
+          閉じる
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="tag-suggest" class="hidden"></div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -7,12 +7,11 @@ crumb :root do
   link "ホーム", root_path
 end
 
-
 # ============================================================
 # 一般（Public）エリア
 # ============================================================
 
-# --- Code Editor ---
+# --- Editor（トップ） ---
 crumb :editor do
   parent :root
   link "Code Editor", editor_path
@@ -29,10 +28,16 @@ crumb :book do |book|
   link book.title, book_path(book)
 end
 
-# 本の中の Section（公開側）
+# 公開側 Section（閲覧）
 crumb :book_section do |book, section|
   parent :book, book
   link "#{section.position}. #{section.heading}", book_section_path(book, section)
+end
+
+# 公開側 Section（編集）
+crumb :book_section_edit do |book, section|
+  parent :book, book
+  link "#{section.position}. #{section.heading}：編集", edit_book_section_path(book, section)
 end
 
 # --- PreCode ---
@@ -88,6 +93,77 @@ crumb :contact do
   link "お問い合わせ", contact_path
 end
 
+# --- Profile（ユーザープロフィール） ---
+crumb :profile do
+  parent :root
+  link "プロフィール", profile_path
+end
+
+crumb :profile_edit do
+  parent :profile
+  link "編集", edit_profile_path
+end
+
+# --- Quizzes（公開） ---
+# クイズ一覧
+crumb :quizzes do
+  parent :root
+  link "クイズ一覧", quizzes_path
+end
+
+# クイズ詳細（クイズのトップ：セクション一覧など）
+crumb :quiz do |quiz|
+  parent :quizzes
+  link quiz.title, quiz_path(quiz)
+end
+
+# セクション一覧（/quizzes/:quiz_id/sections）
+crumb :quiz_sections do |quiz|
+  parent :quiz, quiz
+  link "セクション一覧", quiz_sections_path(quiz)
+end
+
+# セクション詳細（/quizzes/:quiz_id/sections/:id）
+# --- 応急処置：titleに触らず、IDベースのラベル + params フォールバック ---
+crumb :quiz_section_public do |quiz, section|
+  parent :quiz, quiz
+  qid = (quiz && quiz.respond_to?(:id)) ? quiz.id : params[:quiz_id]
+  sid = (section && section.respond_to?(:id)) ? section.id : (params[:section_id] || params[:id])
+  link "セクション ##{sid}", quiz_section_path(qid, sid)
+end
+
+# 問題表示（/quizzes/:quiz_id/sections/:section_id/questions/:id）
+crumb :quiz_question do |quiz, section, question|
+  parent :quiz_section_public, quiz, section
+  link "問題", quiz_section_question_path(quiz, section, question)
+end
+
+# 解答・解説ページ（answer_page）
+crumb :quiz_question_answer_page do |quiz, section, question|
+  parent :quiz_question, quiz, section, question
+  link "解答・解説", answer_page_quiz_section_question_path(quiz, section, question)
+end
+
+# セクション結果ページ（result）
+# --- 応急処置：params フォールバック ---
+crumb :quiz_section_result do |quiz, section|
+  parent :quiz_section_public, quiz, section
+  qid = (quiz && quiz.respond_to?(:id)) ? quiz.id : params[:quiz_id]
+  sid = (section && section.respond_to?(:id)) ? section.id : (params[:section_id] || params[:id])
+  link "結果", result_quiz_section_path(qid, sid)
+end
+
+# 問題編集（公開側の編集画面はルートに存在。学習用に置いておく）
+crumb :quiz_question_edit do |quiz, section, question|
+  parent :quiz_question, quiz, section, question
+  link "編集", edit_quiz_section_question_path(quiz, section, question)
+end
+
+# クイズ空画面（URLが無い想定なのでリンク無しで表記だけ）
+crumb :quiz_empty do
+  parent :quizzes
+  link "空のクイズ", nil
+end
 
 # ============================================================
 # 管理（Admin）エリア
@@ -99,50 +175,179 @@ crumb :admin_root do
   link "ダッシュボード", admin_root_path
 end
 
+# --- Admin: Users ---
+crumb :admin_users do
+  parent :admin_root
+  link "ユーザー管理", admin_users_path
+end
+
 # --- Admin: Books ---
 crumb :admin_books do
   parent :admin_root
   link "Books", admin_books_path
 end
 
-# 管理側 Book 詳細（show が無いなら edit にしてOK）
 crumb :admin_book do |book|
   parent :admin_books
-  link book.title, admin_book_path(book) # showが無ければ edit_admin_book_path(book) に変更可
+  link book.title, admin_book_path(book) # show が無ければ edit に差し替え
 end
 
-# Admin: Books 新規作成
 crumb :admin_book_new do
   parent :admin_books
   link "新規作成", new_admin_book_path
 end
 
-# 管理側 Book 編集（「タイトル：編集」表記）
 crumb :admin_book_edit do |book|
   parent :admin_books
   link "#{book.title}：編集", edit_admin_book_path(book)
 end
 
-# --- Admin: Sections ---
+# --- Admin: Book Sections ---
 crumb :admin_book_sections do
   parent :admin_root
   link "Sections", admin_book_sections_path
 end
 
-# 管理側 Section 詳細（show が無ければ edit にしてOK）
 crumb :admin_book_section do |section|
   parent :admin_book_sections
-  link section.heading, admin_book_section_path(section) # showが無ければ edit_admin_book_section_path(section)
+  link section.heading, admin_book_section_path(section) # show が無ければ edit に差し替え
 end
 
-# Admin: Book Sections 新規作成
 crumb :admin_book_section_new do
   parent :admin_book_sections
   link "新規作成", new_admin_book_section_path
 end
 
-# 管理側 Section 編集（「見出し：編集」表記）
 crumb :admin_book_section_edit do |section|
   parent :admin_book_sections
   link "#{section.heading}：編集", edit_admin_book_section_path(section)
+end
+
+# --- Admin: PreCodes ---
+crumb :admin_pre_codes do
+  parent :admin_root
+  link "PreCode 管理", admin_pre_codes_path
+end
+
+crumb :admin_pre_code do |code|
+  parent :admin_pre_codes
+  link code.title, admin_pre_code_path(code)
+end
+
+crumb :admin_pre_code_edit do |code|
+  parent :admin_pre_codes
+  link "#{code.title}：編集", edit_admin_pre_code_path(code)
+end
+
+# --- Admin: Tags ---
+crumb :admin_tags do
+  parent :admin_root
+  link "タグ管理", admin_tags_path
+end
+
+# --- Admin: Quizzes（作成系） ---
+crumb :admin_quizzes do
+  parent :admin_root
+  link "クイズ（作成）", admin_quizzes_path
+end
+
+crumb :admin_quiz_new do
+  parent :admin_quizzes
+  link "新規作成", new_admin_quiz_path
+end
+
+crumb :admin_quiz do |quiz|
+  parent :admin_quizzes
+  link quiz.title, admin_quiz_path(quiz)
+end
+
+crumb :admin_quiz_edit do |quiz|
+  parent :admin_quizzes
+  link "#{quiz.title}：編集", edit_admin_quiz_path(quiz)
+end
+
+# --- Admin: Quiz Sections ---
+crumb :admin_quiz_sections do
+  parent :admin_root
+  link "クイズ Sections", admin_quiz_sections_path
+end
+
+crumb :admin_quiz_section_new do
+  parent :admin_quiz_sections
+  link "新規作成", new_admin_quiz_section_path
+end
+
+crumb :admin_quiz_section do |section|
+  parent :admin_quiz_sections
+  link section.title, admin_quiz_section_path(section)
+end
+
+# --- 応急処置：titleに触らず、params[:id] フォールバック ---
+crumb :admin_quiz_section_edit do |section|
+  parent :admin_quiz_sections
+  sid = (section && section.respond_to?(:id)) ? section.id : params[:id]
+  link "セクション ##{sid}：編集", edit_admin_quiz_section_path(sid)
+end
+
+# --- Admin: Quiz Questions ---
+crumb :admin_quiz_questions do
+  parent :admin_root
+  link "クイズ Questions", admin_quiz_questions_path
+end
+
+crumb :admin_quiz_question_new do
+  parent :admin_quiz_questions
+  link "新規作成", new_admin_quiz_question_path
+end
+
+crumb :admin_quiz_question do |question|
+  parent :admin_quiz_questions
+  link "問題 ##{question.id}", admin_quiz_question_path(question)
+end
+
+# --- 応急処置：question が nil でも params[:id] で表示 ---
+crumb :admin_quiz_question_edit do |question|
+  parent :admin_quiz_questions
+  qid = (question && question.respond_to?(:id)) ? question.id : params[:id]
+  link "問題 ##{qid}：編集", edit_admin_quiz_question_path(qid)
+end
+
+# --- Admin: Editor Permissions ---
+crumb :admin_editor_permissions do
+  parent :admin_root
+  link "Editor Permissions", admin_editor_permissions_path
+end
+
+crumb :new_admin_editor_permission do
+  parent :admin_editor_permissions
+  link "新規作成", new_admin_editor_permission_path
+end
+
+crumb :bulk_new_admin_editor_permissions do
+  parent :admin_editor_permissions
+  link "一括付与", bulk_new_admin_editor_permissions_path
+end
+
+# --- 応急処置：perm が nil でも params[:id] で表示 ---
+crumb :admin_editor_permission do |perm|
+  parent :admin_editor_permissions
+  pid = (perm && perm.respond_to?(:id)) ? perm.id : params[:id]
+  link "##{pid}", admin_editor_permission_path(pid)
+end
+
+crumb :edit_admin_editor_permission do |perm|
+  parent :admin_editor_permissions
+  pid = (perm && perm.respond_to?(:id)) ? perm.id : params[:id]
+  link "##{pid}：編集", edit_admin_editor_permission_path(pid)
+end
+
+# --- Admin: Versions（バージョン管理） ---
+crumb :admin_versions do
+  parent :admin_root
+  link "変更履歴", admin_versions_path
+end
+
+crumb :admin_version do |version|
+  parent :admin_versions
+  link "##{version.id}", admin_version_path(version)
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,6 +13,12 @@ ja:
       long: "%Y年%-m月%-d日 %H:%M"
       ymd_hm: "%Y/%m/%d %H:%M"
 
+  editor:
+    errors:
+      blank: "code が空です"
+      too_large: "code が大きすぎます"
+      forbidden_chars: "禁止された制御文字が含まれています"
+
   activerecord:
     models:
       pre_code: "PreCode"
@@ -32,7 +38,11 @@ ja:
         lock_version: "更新番号"
       pre_code:
         title: "タイトル"
-        body: "コードの説明"
+        description: "問題文"
+        body: "登録コード"
+        hint: "ヒント"
+        answer: "解答"
+        answer_code: "解答コード"
       book:
         title: "タイトル"
         description: "説明"
@@ -67,16 +77,42 @@ ja:
         lock_version: "更新番号"
         created_at: "作成日時"
         updated_at: "更新日時"
+      user:
+        name: "ユーザー名"
+        email: "メールアドレス"
+        password: "パスワード"
 
     errors:
       models:
         book:
           attributes:
+            title:
+              blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
+            description:
+              blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
             position:
               blank: "を入力してください"
               not_a_number: "は数値で入力してください"
+              not_an_integer: "は整数で入力してください"
               greater_than: "は%{count}より大きい値にしてください"
+              less_than_or_equal_to: "は%{count}以下にしてください"
               taken: "はすでに使用されています"
+        book_section:
+          attributes:
+            heading:
+              blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
+            content:
+              blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
+            position:
+              blank: "を入力してください"
+              not_a_number: "は数値で入力してください"
+              not_an_integer: "は整数で入力してください"
+              greater_than_or_equal_to: "は%{count}以上にしてください"
+              less_than_or_equal_to: "は%{count}以下にしてください"
         quiz:
           attributes:
             title:
@@ -90,6 +126,7 @@ ja:
               not_a_number: "は数値で入力してください"
               not_an_integer: "は整数で入力してください"
               greater_than: "は%{count}より大きい値にしてください"
+              less_than_or_equal_to: "は%{count}以下にしてください"
         quiz_section:
           attributes:
             quiz:
@@ -104,6 +141,7 @@ ja:
               not_a_number: "は数値で入力してください"
               not_an_integer: "は整数で入力してください"
               greater_than: "は%{count}より大きい値にしてください"
+              less_than_or_equal_to: "は%{count}以下にしてください"
         quiz_question:
           attributes:
             quiz:
@@ -112,16 +150,22 @@ ja:
               blank: "を選択してください"
             question:
               blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
             explanation:
               blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
             choice1:
               blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
             choice2:
               blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
             choice3:
               blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
             choice4:
               blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
             correct_choice:
               blank: "を入力してください"
               inclusion: "は1〜4のいずれかを指定してください"
@@ -130,6 +174,43 @@ ja:
               not_a_number: "は数値で入力してください"
               not_an_integer: "は整数で入力してください"
               greater_than: "は%{count}より大きい値にしてください"
+              less_than_or_equal_to: "は%{count}以下にしてください"
+        pre_code:
+          attributes:
+            title:
+              blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
+              blank_only: "を空白だけにはできません"
+            description:
+              too_long: "は%{count}文字以内で入力してください"
+            body:
+              blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
+            hint:
+              too_long: "は%{count}文字以内で入力してください"
+            answer:
+              blank: "を入力してください（問題モード）"
+              too_long: "は%{count}文字以内で入力してください"
+            answer_code:
+              too_long: "は%{count}文字以内で入力してください"
+        editor_permission:
+          attributes:
+            target_id:
+              not_found: "が存在しません"
+        user:
+          attributes:
+            name:
+              blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
+            email:
+              blank: "を入力してください"
+              invalid: "の形式が正しくありません"
+              taken: "はすでに使用されています"
+              too_long: "は%{count}文字以内で入力してください"
+            password:
+              blank: "を入力してください"
+              too_short: "は%{count}文字以上で入力してください"
+              too_long: "は%{count}文字以内で入力してください"
 
   helpers:
     submit:
@@ -151,6 +232,7 @@ ja:
   errors:
     messages:
       blank: "を入力してください"
+      blank_only: "を空白だけにはできません"
       inclusion: "は一覧にありません"
       exclusion: "は予約されています"
       invalid: "は不正な値です"
@@ -170,6 +252,7 @@ ja:
       other_than: "は%{count}以外の値にしてください"
       odd: "は奇数を指定してください"
       even: "は偶数を指定してください"
+      too_many_images: "%{max}枚以下にしてください"
 
   bookmarks:
     limit_reached: "300件以上のブックマーク登録はできません"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,9 @@ Rails.application.routes.draw do
   resources :bookmarks, only: %i[create destroy]
 
   # タグ
-  resources :tags, only: %i[index show]
+  resources :tags, only: [ :index, :show, :create ] do
+    collection { get :popular }
+  end
 
   # Code Editor
   root "editor#index"

--- a/db/migrate/20251009171513_add_zero_since_to_tags.rb
+++ b/db/migrate/20251009171513_add_zero_since_to_tags.rb
@@ -1,0 +1,7 @@
+class AddZeroSinceToTags < ActiveRecord::Migration[8.0]
+  def change
+    add_column :tags, :zero_since, :datetime
+    add_index  :tags, :zero_since
+    add_index  :tags, :taggings_count
+  end
+end

--- a/db/migrate/20251009172853_add_cross_links_between_book_and_quiz_sections.rb
+++ b/db/migrate/20251009172853_add_cross_links_between_book_and_quiz_sections.rb
@@ -1,0 +1,15 @@
+class AddCrossLinksBetweenBookAndQuizSections < ActiveRecord::Migration[8.0]
+  def change
+    # book_sections.quiz_section_id（任意／削除時は null）
+    add_column :book_sections, :quiz_section_id, :bigint
+    add_index  :book_sections, :quiz_section_id
+    add_foreign_key :book_sections, :quiz_sections,
+                    column: :quiz_section_id, on_delete: :nullify
+
+    # quiz_sections.book_section_id（任意／削除時は null）
+    add_column :quiz_sections, :book_section_id, :bigint
+    add_index  :quiz_sections, :book_section_id
+    add_foreign_key :quiz_sections, :book_sections,
+                    column: :book_section_id, on_delete: :nullify
+  end
+end

--- a/db/migrate/20251009180431_add_soft_limits_and_checks.rb
+++ b/db/migrate/20251009180431_add_soft_limits_and_checks.rb
@@ -1,0 +1,72 @@
+class AddSoftLimitsAndChecks < ActiveRecord::Migration[8.0]
+  def up
+    # ====== string 長さ制限（DBレベル） ======
+    change_column :books,          :title, :string, limit: 100
+    change_column :quizzes,        :title, :string, limit: 100
+    change_column :book_sections,  :heading, :string, limit: 50
+    change_column :quiz_sections,  :heading, :string, limit: 100
+    change_column :quiz_questions, :choice1, :string, limit: 100
+    change_column :quiz_questions, :choice2, :string, limit: 100
+    change_column :quiz_questions, :choice3, :string, limit: 100
+    change_column :quiz_questions, :choice4, :string, limit: 100
+    change_column :users,          :name,  :string, limit: 50
+    change_column :users,          :email, :string, limit: 255
+    change_column :pre_codes,      :title, :string, limit: 50
+
+    # ====== 数値の上限（CHECK で 0..9999 を担保） ======
+    add_check(:books,         "position_range",         "position > 0 AND position <= 9999")
+    add_check(:quizzes,       "position_range",         "position > 0 AND position <= 9999")
+    add_check(:quiz_sections, "position_range",         "position > 0 AND position <= 9999")
+    add_check(:quiz_questions, "position_range",         "position > 0 AND position <= 9999")
+    add_check(:book_sections, "position_range",         "position >= 0 AND position <= 9999")
+
+    # ====== text カラムの長さ上限（char_length） ======
+    add_check(:books,         "description_len",  "char_length(description) <= 1000")
+    add_check(:quizzes,       "description_len",  "char_length(description) <= 1000")
+    add_check(:book_sections, "content_len",      "char_length(content) <= 30000")
+    add_check(:pre_codes,     "description_len",  "description IS NULL OR char_length(description) <= 2000")
+    add_check(:pre_codes,     "body_len",         "char_length(body) <= 5000")
+    add_check(:pre_codes,     "hint_len",         "hint IS NULL OR char_length(hint) <= 1000")
+    add_check(:pre_codes,     "answer_len",       "answer IS NULL OR char_length(answer) <= 2000")
+    add_check(:pre_codes,     "answer_code_len",  "answer_code IS NULL OR char_length(answer_code) <= 2000")
+    add_check(:quiz_questions, "question_len",     "char_length(question) <= 2000")
+    add_check(:quiz_questions, "explanation_len",  "char_length(explanation) <= 2000")
+  end
+
+  def down
+    # string limit は戻さず（安全側）。CHECK は削除
+    drop_check(:books,         "position_range")
+    drop_check(:quizzes,       "position_range")
+    drop_check(:quiz_sections, "position_range")
+    drop_check(:quiz_questions, "position_range")
+    drop_check(:book_sections, "position_range")
+
+    drop_check(:books,         "description_len")
+    drop_check(:quizzes,       "description_len")
+    drop_check(:book_sections, "content_len")
+    drop_check(:pre_codes,     "description_len")
+    drop_check(:pre_codes,     "body_len")
+    drop_check(:pre_codes,     "hint_len")
+    drop_check(:pre_codes,     "answer_len")
+    drop_check(:pre_codes,     "answer_code_len")
+    drop_check(:quiz_questions, "question_len")
+    drop_check(:quiz_questions, "explanation_len")
+  end
+
+  private
+
+  def add_check(table, name, expr)
+    execute <<~SQL
+      ALTER TABLE #{table}
+      ADD CONSTRAINT #{table}_#{name}_chk
+      CHECK (#{expr})
+    SQL
+  end
+
+  def drop_check(table, name)
+    execute <<~SQL
+      ALTER TABLE #{table}
+      DROP CONSTRAINT IF EXISTS #{table}_#{name}_chk
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_01_044757) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_09_180431) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -55,15 +55,19 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_044757) do
 
   create_table "book_sections", force: :cascade do |t|
     t.bigint "book_id", null: false
-    t.string "heading", null: false
+    t.string "heading", limit: 50, null: false
     t.text "content", null: false
     t.boolean "is_free", default: false, null: false
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "lock_version", default: 0, null: false
+    t.bigint "quiz_section_id"
     t.index ["book_id", "position"], name: "index_book_sections_on_book_id_and_position", unique: true
     t.index ["book_id"], name: "index_book_sections_on_book_id"
+    t.index ["quiz_section_id"], name: "index_book_sections_on_quiz_section_id"
+    t.check_constraint "\"position\" >= 0 AND \"position\" <= 9999", name: "book_sections_position_range_chk"
+    t.check_constraint "char_length(content) <= 30000", name: "book_sections_content_len_chk"
   end
 
   create_table "bookmarks", force: :cascade do |t|
@@ -77,13 +81,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_044757) do
   end
 
   create_table "books", force: :cascade do |t|
-    t.string "title", null: false
+    t.string "title", limit: 100, null: false
     t.text "description", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "book_sections_count", default: 0, null: false
     t.integer "position", null: false
     t.index ["position"], name: "index_books_on_position", unique: true
+    t.check_constraint "\"position\" > 0 AND \"position\" <= 9999", name: "books_position_range_chk"
+    t.check_constraint "char_length(description) <= 1000", name: "books_description_len_chk"
   end
 
   create_table "editor_permissions", force: :cascade do |t|
@@ -120,7 +126,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_044757) do
 
   create_table "pre_codes", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "title", null: false
+    t.string "title", limit: 50, null: false
     t.text "description"
     t.text "body", null: false
     t.integer "like_count", default: 0, null: false
@@ -133,16 +139,21 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_044757) do
     t.index ["title"], name: "index_pre_codes_on_title"
     t.index ["user_id", "created_at"], name: "index_pre_codes_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_pre_codes_on_user_id"
+    t.check_constraint "answer IS NULL OR char_length(answer) <= 2000", name: "pre_codes_answer_len_chk"
+    t.check_constraint "answer_code IS NULL OR char_length(answer_code) <= 2000", name: "pre_codes_answer_code_len_chk"
+    t.check_constraint "char_length(body) <= 5000", name: "pre_codes_body_len_chk"
+    t.check_constraint "description IS NULL OR char_length(description) <= 2000", name: "pre_codes_description_len_chk"
+    t.check_constraint "hint IS NULL OR char_length(hint) <= 1000", name: "pre_codes_hint_len_chk"
   end
 
   create_table "quiz_questions", force: :cascade do |t|
     t.bigint "quiz_id", null: false
     t.bigint "quiz_section_id", null: false
     t.text "question", null: false
-    t.string "choice1", null: false
-    t.string "choice2", null: false
-    t.string "choice3", null: false
-    t.string "choice4", null: false
+    t.string "choice1", limit: 100, null: false
+    t.string "choice2", limit: 100, null: false
+    t.string "choice3", limit: 100, null: false
+    t.string "choice4", limit: 100, null: false
     t.integer "correct_choice", null: false
     t.text "explanation", null: false
     t.integer "position", null: false
@@ -152,26 +163,34 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_044757) do
     t.index ["quiz_id"], name: "index_quiz_questions_on_quiz_id"
     t.index ["quiz_section_id", "position"], name: "index_quiz_questions_on_quiz_section_id_and_position"
     t.index ["quiz_section_id"], name: "index_quiz_questions_on_quiz_section_id"
+    t.check_constraint "\"position\" > 0 AND \"position\" <= 9999", name: "quiz_questions_position_range_chk"
+    t.check_constraint "char_length(explanation) <= 2000", name: "quiz_questions_explanation_len_chk"
+    t.check_constraint "char_length(question) <= 2000", name: "quiz_questions_question_len_chk"
   end
 
   create_table "quiz_sections", force: :cascade do |t|
     t.bigint "quiz_id", null: false
-    t.string "heading", null: false
+    t.string "heading", limit: 100, null: false
     t.boolean "is_free", default: false, null: false
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "book_section_id"
+    t.index ["book_section_id"], name: "index_quiz_sections_on_book_section_id"
     t.index ["quiz_id", "position"], name: "index_quiz_sections_on_quiz_id_and_position"
     t.index ["quiz_id"], name: "index_quiz_sections_on_quiz_id"
+    t.check_constraint "\"position\" > 0 AND \"position\" <= 9999", name: "quiz_sections_position_range_chk"
   end
 
   create_table "quizzes", force: :cascade do |t|
-    t.string "title", null: false
+    t.string "title", limit: 100, null: false
     t.text "description", null: false
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["position"], name: "index_quizzes_on_position"
+    t.check_constraint "\"position\" > 0 AND \"position\" <= 9999", name: "quizzes_position_range_chk"
+    t.check_constraint "char_length(description) <= 1000", name: "quizzes_description_len_chk"
   end
 
   create_table "solid_cache_entries", id: false, force: :cascade do |t|
@@ -193,8 +212,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_044757) do
     t.integer "taggings_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "zero_since"
     t.index ["name_norm"], name: "index_tags_on_name_norm", unique: true
     t.index ["slug"], name: "index_tags_on_slug", unique: true
+    t.index ["taggings_count"], name: "index_tags_on_taggings_count"
+    t.index ["zero_since"], name: "index_tags_on_zero_since"
     t.check_constraint "color IS NULL OR color::text ~ '^#[0-9A-Fa-f]{6}$'::text", name: "tags_color_hex"
   end
 
@@ -244,6 +266,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_044757) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "authentications", "users", on_delete: :cascade
   add_foreign_key "book_sections", "books"
+  add_foreign_key "book_sections", "quiz_sections", on_delete: :nullify
   add_foreign_key "bookmarks", "pre_codes", on_delete: :cascade
   add_foreign_key "bookmarks", "users"
   add_foreign_key "editor_permissions", "users"
@@ -254,6 +277,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_044757) do
   add_foreign_key "pre_codes", "users"
   add_foreign_key "quiz_questions", "quiz_sections"
   add_foreign_key "quiz_questions", "quizzes"
+  add_foreign_key "quiz_sections", "book_sections", on_delete: :nullify
   add_foreign_key "quiz_sections", "quizzes"
   add_foreign_key "used_codes", "pre_codes"
   add_foreign_key "used_codes", "users"

--- a/lib/tasks/tags.rake
+++ b/lib/tasks/tags.rake
@@ -1,0 +1,10 @@
+# lib/tasks/tags.rake
+namespace :tags do
+  desc "未使用が一定期間続くタグを削除（既定: 10日）"
+  task :cleanup_unused, [ :days ] => :environment do |_t, args|
+    days = (args[:days].presence || 10).to_i
+    puts "[tags:cleanup_unused] start (days=#{days})"
+    Tag.cleanup_unused!(older_than: days.days)
+    puts "[tags:cleanup_unused] done"
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -2,5 +2,6 @@
 FactoryBot.define do
   factory :tag do
     sequence(:name) { |n| "tag#{n}" }
+    # zero_since は状況に応じてテスト内で明示設定
   end
 end

--- a/spec/models/book_section_spec.rb
+++ b/spec/models/book_section_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Book, type: :model do
       expect(b.errors[:title]).to be_present
     end
 
-    it "is invalid when description is over 500 chars" do
-      b = build(:book, description: "a" * 501)
+    it "is invalid when description is over 1000 chars" do
+      b = build(:book, description: "a" * 1001)
       expect(b).to be_invalid
       expect(b.errors[:description]).to be_present
     end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Book, type: :model do
   describe "validations" do
-    it "is valid with title, description and position" do
+    it "is valid with title and description" do
       expect(build(:book)).to be_valid
     end
 
@@ -13,27 +13,10 @@ RSpec.describe Book, type: :model do
       expect(b.errors[:title]).to be_present
     end
 
-    it "is invalid when description is over 500 chars" do
-      b = build(:book, description: "a" * 501)
+    it "is invalid when description is over 1000 chars" do
+      b = build(:book, description: "a" * 1001)
       expect(b).to be_invalid
       expect(b.errors[:description]).to be_present
-    end
-
-    it "validates position is integer > 0" do
-      b = build(:book, position: 0)
-      expect(b).to be_invalid
-      expect(b.errors[:position]).to be_present
-
-      b2 = build(:book, position: 1.5)
-      expect(b2).to be_invalid
-      expect(b2.errors[:position]).to be_present
-    end
-
-    it "validates position uniqueness" do
-      create(:book, position: 10)
-      dup = build(:book, position: 10)
-      expect(dup).to be_invalid
-      expect(dup.errors[:position]).to be_present
     end
   end
 

--- a/spec/models/pre_code_tagging_spec.rb
+++ b/spec/models/pre_code_tagging_spec.rb
@@ -1,10 +1,31 @@
 # spec/models/pre_code_tagging_spec.rb
 require "rails_helper"
+
 RSpec.describe PreCodeTagging, type: :model do
   it "pre_code と tag の組が一意" do
     pc = create(:pre_code)
     tag = create(:tag)
     create(:pre_code_tagging, pre_code: pc, tag: tag)
     expect { create(:pre_code_tagging, pre_code: pc, tag: tag) }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  it "作成/削除で tag.zero_since が適切に更新される" do
+    pc  = create(:pre_code)
+    tag = create(:tag)
+
+    # 作成で使用開始 → zero_since は nil
+    create(:pre_code_tagging, pre_code: pc, tag: tag)
+    expect(tag.reload.zero_since).to be_nil
+    expect(tag.taggings_count).to eq(1)
+
+    # 削除で未使用化 → zero_since が入る
+    PreCodeTagging.where(pre_code: pc, tag: tag).first.destroy!
+    expect(tag.reload.taggings_count).to eq(0)
+    expect(tag.zero_since).to be_present
+
+    # 再度使用開始 → zero_since は nil に戻る
+    create(:pre_code_tagging, pre_code: pc, tag: tag)
+    expect(tag.reload.taggings_count).to eq(1)
+    expect(tag.zero_since).to be_nil
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,8 +1,30 @@
 # spec/models/tag_spec.rb
 require "rails_helper"
+
 RSpec.describe Tag, type: :model do
   it "name_norm が一意になる" do
     create(:tag, name: "Ruby")
     expect { create(:tag, name: " ruby ") }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  describe ".cleanup_unused!" do
+    it "zero_since が10日以上の未使用タグを削除する" do
+      old_unused = create(:tag, name: "old-zero")
+      recent_unused = create(:tag, name: "recent-zero")
+      used = create(:tag, name: "used")
+
+      # 擬似的に zero を設定
+      old_unused.update!(taggings_count: 0, zero_since: 11.days.ago)
+      recent_unused.update!(taggings_count: 0, zero_since: 5.days.ago)
+      used.update!(taggings_count: 1, zero_since: nil)
+
+      expect {
+        Tag.cleanup_unused!(older_than: 10.days)
+      }.to change(Tag, :count).by(-1)
+
+      expect(Tag.exists?(old_unused.id)).to be_falsey
+      expect(Tag.exists?(recent_unused.id)).to be_truthy
+      expect(Tag.exists?(used.id)).to be_truthy
+    end
   end
 end

--- a/spec/requests/admin/tags_spec.rb
+++ b/spec/requests/admin/tags_spec.rb
@@ -17,4 +17,11 @@ RSpec.describe "Admin::Tags", type: :request do
     t = create(:tag, name: "unused")
     expect { delete admin_tag_path(t) }.to change(Tag, :count).by(-1)
   end
+
+  it "index に未使用タグも表示される" do
+    sign_in admin
+    create(:tag, name: "unused") # taggings_count: 0
+    get admin_tags_path
+    expect(response.body).to include("unused")
+  end
 end


### PR DESCRIPTION
### 概要
主要ページと管理画面にパンくず（Gretel）を実装し、ナビゲーション性を向上させた。

**作業内容**

- gretel を導入し、config/breadcrumbs.rb を整理して作成
- 表示用パーシャル app/views/shared/_breadcrumbs.html.erb を追加
- 各ビューにパンくずキーを配置：Editor、Books、BookSections、PreCode、CodeLibrary、Admin
- クリック不可問題・管理パンくずの起点を「ダッシュボード」に修正し、動作確認・簡易リファクタを実施