### PR TITLE
UI共通化とクイズUX刷新：選択肢ボタン化・ピル/赤ボタン/トグルの共通クラス追加、各画面の導線/スタイル統一、削除ボタンを変更系バリアント化

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -71,3 +71,181 @@
   background: #fff;
   border-bottom: 1px solid #e5e7eb;
 }
+
+/* ===========================
+   Reveal系トグルボタンの共通クラス
+   （「🔰 初めての方へ」「表示/非表示」など）
+   =========================== */
+@layer components {
+  .btn-toggle{
+    @apply px-3 py-1 rounded text-sm ring-1 ring-slate-300 transition;
+  }
+  .btn-toggle:hover{
+    @apply bg-black text-white ring-black;
+  }
+  .btn-toggle:active{
+    @apply bg-slate-900;
+  }
+  .btn-toggle:focus-visible{
+    @apply outline-none ring-2 ring-slate-400;
+  }
+}
+
+/* 既存テンプレが残っていても hover だけは効かせたい場合の保険（任意） */
+button[data-reveal-target="button"] {
+  @apply transition;
+}
+button[data-reveal-target="button"]:hover {
+  @apply bg-black text-white ring-black;
+}
+button[data-reveal-target="button"]:active {
+  @apply bg-slate-900;
+}
+button[data-reveal-target="button"]:focus-visible {
+  @apply outline-none ring-2 ring-slate-400;
+}
+
+/* ===========================
+   変更系ボタン（アウトライン → ホバーで塗りつぶし）
+   - 共通: .btn-change
+   - 色バリアント: .is-edit（緑）, .is-delete（赤）
+   - 仕組み: CSSカスタムプロパティ --btnc / --btnc-active を色に使用
+   =========================== */
+@layer components {
+  .btn-change{
+    /* ベース（形・余白・タイポ・アウトライン） */
+    @apply inline-flex items-center justify-center
+           rounded px-3 py-1 text-sm font-medium
+           transition bg-white ring-1;
+    /* 色（テキスト/ボーダー=同色） */
+    color: var(--btnc);
+    --tw-ring-color: var(--btnc);
+  }
+  .btn-change:hover{
+    /* 反転（塗りつぶし） */
+    @apply text-white;
+    background-color: var(--btnc);
+  }
+  .btn-change:active{
+    /* ほんの少しだけ暗く */
+    background-color: var(--btnc-active, var(--btnc));
+  }
+  .btn-change:focus-visible{
+    @apply outline-none ring-2;
+  }
+
+  /* === バリアント === */
+  .btn-change.is-edit{
+    /* 画像指定の緑 */
+    --btnc: #0E9970;
+    --btnc-active: #0C8B66;
+  }
+  .btn-change.is-delete{
+    /* 既存UIの赤系に合わせた階調 */
+    --btnc: #CC0000;
+    --btnc-active: #BB0000;
+  }
+}
+
+/* ===========================
+   クイズ機能の選択肢ボタン
+   =========================== */
+@layer components {
+  /* 選択肢ボタン（プレーン→Hoverでわずかに強調） */
+  .btn-choice{
+    @apply rounded ring-1 ring-slate-300 bg-white
+           px-4 py-3 text-sm transition
+           hover:bg-slate-50 hover:ring-slate-400
+           active:bg-slate-100
+           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400;
+  }
+}
+
+/* ===========================
+   Pill型アウトラインボタン（Next / 結果を見る）共通
+   ・見た目や余白、丸み、hover時の反転は共通
+   ・色だけを --btnc で差し替え
+   ・色の指定は .is-mint / .is-orange で付与（必要に応じて色クラスを追加）
+   =========================== */
+@layer components {
+  .btn-pill{
+    /* 形・余白・タイポなどの共通部分 */
+    @apply inline-flex items-center gap-2 rounded-full px-6 py-2
+           text-sm font-semibold bg-white transition-colors
+           focus:outline-none;
+    /* 色はカスタムプロパティで一元化（デフォルトは黒） */
+    border: 1px solid var(--btnc, #000);
+    color: var(--btnc, #000);
+  }
+  .btn-pill:hover{
+    background: var(--btnc, #000);
+    color: #fff;
+  }
+
+  /* フォーカス見やすさ（色に合わせた外枠）。color-mixが未対応でも見えるように個別指定も下で用意 */
+  .btn-pill:focus-visible{
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--btnc) 50%, transparent);
+  }
+
+  /* === 色指定（必要に応じて増やせます） === */
+  .btn-pill.is-mint   { --btnc: #2ED6B5; } /* ミント系 */
+  .btn-pill.is-orange { --btnc: #FF8A5B; } /* 鮮やかなオレンジ */
+  .btn-pill.is-red   { --btnc: #CC0000; } /* ヘッダーと同じ赤（紅）*/
+
+  /* color-mix 非対応ブラウザ向けのフォールバック（半透明の外枠） */
+  .btn-pill.is-mint:focus-visible   { box-shadow: 0 0 0 2px rgba(46, 214, 181, .5); }
+  .btn-pill.is-orange:focus-visible { box-shadow: 0 0 0 2px rgba(255, 138,  91, .5); }
+  .btn-pill:active   { filter: brightness(.95); }
+}
+
+/* ===========================
+   白背景 黒文字ボタン（大）（共通）
+   - 既定: 白背景 / 黒文字 / 灰色リング
+   - hover: 黒背景 / 白文字 / 黒リング
+   - 用途: 「タグを選ぶ」「テーマ切替」など
+   =========================== */
+@layer components {
+  .btn-bg-white{
+    @apply inline-flex items-center justify-center
+           px-3 py-2 rounded text-sm
+           bg-white text-slate-900
+           ring-1 ring-slate-300
+           transition-colors;
+  }
+  .btn-bg-white:hover{
+    @apply bg-black text-white ring-black;
+  }
+  .btn-bg-white:active{
+    @apply bg-slate-900;
+  }
+  .btn-bg-white:focus-visible{
+    @apply outline-none ring-2 ring-slate-600;
+  }
+}
+
+/* ===========================
+   赤ベタボタン（共通）
+   - 既定: 赤背景 / 白文字
+   - hover: 少し暗い赤
+   - active: さらに暗い赤
+   - 用途: 検索/実行/リンク 等の通常幅
+   =========================== */
+@layer components {
+  .btn-solid-red{
+    @apply inline-flex items-center justify-center
+           rounded px-3 py-2 text-sm font-medium
+           bg-[#CC0000] text-white
+           transition hover:bg-[#BB0000] active:bg-[#AA0000]
+           focus:outline-none focus:ring-2 focus:ring-[#CC0000];
+  }
+
+  /* 横長版（固定幅） */
+  .btn-solid-red--wide{
+    @apply inline-flex items-center justify-center
+           w-64 rounded px-4 py-2 text-base font-medium
+           bg-[#CC0000] text-white
+           transition hover:bg-[#BB0000] active:bg-[#AA0000]
+           focus:outline-none focus:ring-2 focus:ring-[#CC0000];
+  }
+}
+

--- a/app/views/book_sections/edit.html.erb
+++ b/app/views/book_sections/edit.html.erb
@@ -15,8 +15,7 @@
     <div id="quill-editor" class="bg-white rounded min-h-[18rem] mb-6 ql-container ql-snow"></div>
     <%= f.hidden_field :content, id: "content_field", autocomplete: "off" %>
   </div>
-  <div class="mt-4">
-    <%= f.submit "更新する", class: "px-4 py-2 rounded bg-slate-900 text-white" %>
-    <%= link_to "戻る", book_section_path(@book, @section), class: "ml-2 underline" %>
+  <div class="mt-6 flex justify-center">
+    <%= f.submit "更新する", class: "btn-solid-red--wide" %>
   </div>
 <% end %>

--- a/app/views/book_sections/show.html.erb
+++ b/app/views/book_sections/show.html.erb
@@ -9,9 +9,9 @@
   </nav>
 
   <% if can_edit?(@section) %>
-    <div class="mb-4">
+    <div class="flex justify-end mb-4">
       <%= link_to "編集", edit_book_section_path(@book, @section),
-            class: "inline-block px-3 py-1 rounded bg-slate-900 text-white text-sm" %>
+            class: "btn-change is-edit" %>
     </div>
   <% end %>
 
@@ -25,37 +25,36 @@
     <%= render_section_content(@section) %>
   </article>
 
-  <!-- ===== アウトプットシェア ===== -->
-  <div class="mt-12 text-center space-y-3"
+  <!-- ===== シェア & クイズ遷移ボタン ===== -->
+  <h1 class="mt-12 text-2xl font-semibold">次の章に行く前に...</h1>
+  <div class="text-center space-y-3"
        data-controller="share"
        data-share-url-value="<%= books_url %>">
+    <% if @section.quiz_section.present? %>
+      <div class="mt-4 p-5 rounded-xl ring-1 ring-slate-200 bg-white">
+        <p class="text-xl font-semibold mt-2 mb-3">この章で学んだ知識を覚えよう！</p>
 
-    <h1 class="text-lg font-semibold">次の章に行く前に...</h1>
-    <p class="text-slate-700 font-medium">
-      この章で学んだことを、Xでアウトプットしてみましょう ✨
-    </p>
+        <p class="text-slate-600 mb-4">
+          この章で学んだことを、Xでアウトプットしましょう ✨
+        </p>
 
-    <button type="button"
-            data-action="share#openTwitter"
-            data-text="<%= "#{@section.heading} を学習しました！ #RailsLearning" %>"
-            class="btn-dark">
-      Xでシェア
-    </button>
+        <button type="button"
+                data-action="share#openTwitter"
+                data-text="<%= "#{@section.heading} を学習しました！ #RailsLearning" %>"
+                class="btn-dark">
+          Xでシェア
+        </button>
+
+        <p class="text-slate-600 mt-8 mb-4">対応するクイズに挑戦して理解を定着させましょう💡</p>
+
+        <%= link_to "クイズを解く",
+              quiz_section_path(@section.quiz_section.quiz, @section.quiz_section),
+              class: "btn-pill is-red" %>
+      </div>
+    <% end %>
   </div>
 
-  <!-- ===== 学んだらクイズで定着！ ===== -->
-  <% if @section.quiz_section.present? %>
-    <div class="mt-10 p-5 rounded-xl ring-1 ring-slate-200 bg-white">
-      <p class="text-lg font-semibold mb-2">この章で学んだ知識を覚えよう！</p>
-      <p class="text-slate-600 mb-4">対応するクイズに挑戦して理解を定着させましょう。</p>
-
-      <%= link_to "クイズを解く",
-            quiz_section_path(@section.quiz_section.quiz, @section.quiz_section),
-            class: "inline-flex items-center rounded-md bg-[#CC0000] px-5 py-2 text-white hover:bg-[#BB0000]" %>
-    </div>
-  <% end %>
-
-  <div class="flex items-center justify-between mt-10 pt-6 border-t">
+  <div class="flex items-center justify-between mt-6 pt-6 border-t">
     <div>
       <% if @prev %>
         <%= link_to "◀ 前へ：#{@prev.heading}",
@@ -73,9 +72,9 @@
   </div>
 
   <% if can_edit?(@section) %>
-    <div class="mb-4">
+    <div class="flex justify-end my-4">
       <%= link_to "編集", edit_book_section_path(@book, @section),
-            class: "inline-block px-3 py-1 rounded bg-slate-900 text-white text-sm" %>
+            class: "btn-change is-edit" %>
     </div>
   <% end %>
 </div>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -15,7 +15,7 @@
   data-reveal-close-label-value="🔰 説明を閉じる">
   <div class="flex justify-end">
     <button type="button"
-            class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+            class="btn-toggle"
             data-reveal-target="button"
             data-action="reveal#toggle">🔰 初めての方へ</button>
   </div>

--- a/app/views/code_libraries/index.html.erb
+++ b/app/views/code_libraries/index.html.erb
@@ -20,7 +20,7 @@
     data-reveal-close-label-value="🔰 説明を閉じる">
     <div class="flex justify-end">
       <button type="button"
-              class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+              class="btn-toggle"
               data-reveal-target="button"
               data-action="reveal#toggle">🔰 初めての方へ</button>
     </div>
@@ -137,7 +137,7 @@ Rubyの標準メソッドを効率的に学習しましょう！
               class: "px-3 py-2 rounded ring-1 ring-slate-300" %>
 
         <%= f.submit "検索",
-              class: "px-3 py-2 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]" %>
+              class: "btn-solid-red" %>
       <% end %>
     </div>
 
@@ -156,7 +156,7 @@ Rubyの標準メソッドを効率的に学習しましょう！
             class: "px-3 py-2 rounded #{on ? 'bg-blue-600 text-white' : 'ring-1 ring-slate-300'}" %>
 
       <%= link_to "使い方", help_path,
-            class: "px-3 py-2 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]" %>
+            class: "btn-solid-red" %>
     </div>
   </div>
 </div>

--- a/app/views/code_libraries/show.html.erb
+++ b/app/views/code_libraries/show.html.erb
@@ -66,7 +66,7 @@
     <section data-controller="reveal" class="space-y-2">
       <div class="flex items-baseline justify-between">
         <h2 class="text-sm font-semibold tracking-wider text-slate-500">ヒント</h2>
-        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+        <button type="button" class="btn-toggle"
                 data-reveal-target="button" data-action="reveal#toggle">表示する</button>
       </div>
 
@@ -101,7 +101,7 @@
     <section data-controller="reveal" class="space-y-2">
       <div class="flex items-baseline justify-between">
         <h2 class="text-sm font-semibold tracking-wider text-slate-500">解答</h2>
-        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+        <button type="button" class="btn-toggle"
                 data-reveal-target="button" data-action="reveal#toggle">表示する</button>
       </div>
 

--- a/app/views/editor/index.html.erb
+++ b/app/views/editor/index.html.erb
@@ -20,7 +20,7 @@
     data-reveal-close-label-value="🔰 説明を閉じる">
     <div class="flex justify-end">
       <button type="button"
-              class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+              class="btn-toggle"
               data-reveal-target="button"
               data-action="reveal#toggle">🔰 初めての方へ</button>
     </div>
@@ -112,7 +112,7 @@ Ruby学習の効率化を図りましょう！！！
     <div data-controller="reveal" class="space-y-2">
       <div class="flex items-baseline justify-between">
         <h3 class="text-sm font-semibold text-slate-500">ヒント</h3>
-        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+        <button type="button" class="btn-toggle"
                 data-reveal-target="button" data-action="reveal#toggle">表示する</button>
       </div>
       <div class="hidden rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3"
@@ -167,14 +167,14 @@ Ruby学習の効率化を図りましょう！！！
     <div class="flex gap-2 pt-2 md:pt-0 md:ml-auto">
       <button type="button"
               data-action="editor#toggleTheme"
-              class="px-3 py-2 rounded ring-1 ring-slate-300">
+              class="btn-bg-white">
         テーマ切替
       </button>
 
       <button type="button"
               data-action="editor#run"
               data-editor-target="runButton"
-              class="px-3 py-2 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]">
+              class="btn-solid-red">
         実行 ▶
       </button>
     </div>
@@ -190,7 +190,7 @@ Ruby学習の効率化を図りましょう！！！
     <div data-controller="reveal" class="space-y-2">
       <div class="flex items-baseline justify-between">
         <h3 class="text-sm font-semibold text-slate-500">解答</h3>
-        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+        <button type="button" class="btn-toggle"
                 data-reveal-target="button" data-action="reveal#toggle">表示する</button>
       </div>
       <div class="hidden rounded-xl ring-1 ring-slate-300 bg-white px-4 py-3"
@@ -200,7 +200,7 @@ Ruby学習の効率化を図りましょう！！！
     <div data-controller="reveal" class="space-y-2">
       <div class="flex items-baseline justify-between">
         <h3 class="text-sm font-semibold text-slate-500">解答コード</h3>
-        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+        <button type="button" class="btn-toggle"
                 data-reveal-target="button" data-action="reveal#toggle">表示する</button>
       </div>
 

--- a/app/views/pre_codes/_form.html.erb
+++ b/app/views/pre_codes/_form.html.erb
@@ -12,7 +12,7 @@
     <%= f.hidden_field :quiz_mode, value: "false", data: { "precode-mode-target": "modeField" } %>
 
     <div class="flex items-center justify-end">
-      <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+      <button type="button" class="btn-toggle"
               data-precode-mode-target="toggle" data-action="precode-mode#switch">
         問題モードにする
       </button>
@@ -40,7 +40,7 @@
              data-tag-picker-target="hiddenInput">
 
       <div class="flex gap-2 items-center">
-        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+        <button type="button" class="btn-toggle"
                 data-action="tag-picker#open">既存のタグを選ぶ</button>
 
         <input type="text" placeholder="タグの新規作成"
@@ -133,6 +133,6 @@
 
   <div class="flex justify-center">
     <%= f.submit (pre_code.new_record? ? "登録" : "更新"),
-          class: "inline-flex justify-center w-64 bg-[#CC0000] text-white px-4 py-2 rounded hover:bg-[#BB0000] active:bg-[#AA0000]" %>
+          class: "btn-solid-red--wide" %>
   </div>
 <% end %>

--- a/app/views/pre_codes/index.html.erb
+++ b/app/views/pre_codes/index.html.erb
@@ -19,7 +19,7 @@
     data-reveal-close-label-value="🔰 説明を閉じる">
     <div class="flex justify-end">
       <button type="button"
-              class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+              class="btn-toggle"
               data-reveal-target="button"
               data-action="reveal#toggle">🔰 初めての方へ</button>
     </div>
@@ -150,7 +150,7 @@ Rubyの標準メソッドを効率的に学習しましょう！
         </div>
 
         <%= f.submit "検索",
-              class: "px-3 py-2 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]" %>
+              class: "btn-solid-red" %>
       <% end %>
     </div>
 
@@ -160,10 +160,10 @@ Rubyの標準メソッドを効率的に学習しましょう！
 
     <div class="flex gap-2 mt-2 justify-end">
       <%= link_to "使い方", help_path,
-            class: "px-3 py-2 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]" %>
+            class: "btn-solid-red" %>
 
       <%= link_to "PreCode 新規作成", new_pre_code_path,
-            class: "px-3 py-2 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]" %>
+            class: "btn-solid-red" %>
     </div>
   </div>
 </div>

--- a/app/views/pre_codes/show.html.erb
+++ b/app/views/pre_codes/show.html.erb
@@ -54,7 +54,7 @@
     <section data-controller="reveal" class="space-y-2">
       <div class="flex items-baseline justify-between">
         <h2 class="text-sm font-semibold tracking-wider text-slate-500">ヒント</h2>
-        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+        <button type="button" class="btn-toggle"
                 data-reveal-target="button" data-action="reveal#toggle">表示する</button>
       </div>
 
@@ -95,7 +95,7 @@
     <section data-controller="reveal" class="space-y-2">
       <div class="flex items-baseline justify-between">
         <h2 class="text-sm font-semibold tracking-wider text-slate-500">解答</h2>
-        <button type="button" class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+        <button type="button" class="btn-toggle"
                 data-reveal-target="button" data-action="reveal#toggle">表示する</button>
       </div>
 
@@ -123,25 +123,19 @@
 
   <!-- === 利用ボタン（中央固定・カウントなし） === -->
   <section class="-mt-2">
-    <div class="grid grid-cols-3 items-center">
-      <div></div>
-      <div class="justify-self-center">
-        <%= link_to "このデータを利用する",
-                    editor_path(pre_code_id: @pre_code.id),
-                    class: "inline-flex justify-center w-64 md:w-80 lg:w-96
-                            bg-[#CC0000] text-white px-4 py-2 rounded
-                            hover:bg-[#BB0000] active:bg-[#AA0000]" %>
-      </div>
-      <div></div>
+    <div class="items-center flex justify-center">
+      <%= link_to "このデータを利用する",
+                  editor_path(pre_code_id: @pre_code.id),
+                  class: "btn-solid-red--wide" %>
     </div>
   </section>
 
   <!-- 操作（右下寄せ） -->
   <div class="-mt-2 flex justify-end space-x-3">
     <%= link_to "編集", edit_pre_code_path(@pre_code),
-          class: "px-5 py-2 rounded-md bg-[#00AA00] text-white hover:bg-[#009900] active:bg-[#008800]" %>
+          class: "btn-change is-edit" %>
     <%= link_to "削除", @pre_code,
           data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
-          class: "px-5 py-2 rounded-md bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]" %>
+          class: "btn-change is-delete" %>
   </div>
 </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -15,7 +15,7 @@
     data-reveal-close-label-value="🔰 説明を閉じる">
     <div class="flex justify-end">
       <button type="button"
-              class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+              class="btn-toggle"
               data-reveal-target="button"
               data-action="reveal#toggle">🔰 初めての方へ</button>
     </div>
@@ -44,8 +44,8 @@
             <%= f.label :name, "表示名", class: "block text-sm mb-1" %>
             <%= f.text_field :name, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2 focus:ring-slate-500" %>
           </div>
-          <div class="pt-2">
-            <%= f.submit "プロフィール更新", class: "rounded-md bg-slate-900 px-4 py-2 text-sm text-white hover:bg-slate-800" %>
+          <div class="pt-2 flex justify-center">
+            <%= f.submit "プロフィール更新", class: "btn-solid-red--wide" %>
           </div>
         </div>
       <% end %>
@@ -70,8 +70,8 @@
             <%= f.label :password_confirmation, "パスワード確認", class: "block text-sm mb-1" %>
             <%= f.password_field :password_confirmation, class: "w-full rounded-xl ring-1 ring-slate-300 px-3 py-2" %>
           </div>
-          <div class="pt-2">
-            <%= f.submit "パスワード更新", class: "rounded-md bg-slate-900 px-4 py-2 text-sm text-white hover:bg-slate-800" %>
+          <div class="pt-2 flex justify-center">
+            <%= f.submit "パスワード更新", class: "btn-solid-red--wide" %>
           </div>
         </div>
       <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -4,22 +4,18 @@
 
 <% content_for :title, "プロフィール" %>
 
-<div class="mx-auto w-full max-w-2xl space-y-6">
-  <div class="flex items-center justify-between">
-    <h1 class="text-xl font-semibold text-slate-900">プロフィール</h1>
-    <%= link_to "編集", edit_profile_path,
-          class: "rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800" %>
-  </div>
+<div class="mx-auto w-full max-w-2xl space-y-3">
+  <h1 class="text-xl font-semibold text-slate-900">プロフィール</h1>
 
   <!-- 🔰 初めての方へ -->
   <section
-    class="-mt-2"
+    class="-mt-1"
     data-controller="reveal"
     data-reveal-open-label-value="🔰 初めての方へ"
     data-reveal-close-label-value="🔰 説明を閉じる">
     <div class="flex justify-end">
       <button type="button"
-              class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+              class="btn-toggle"
               data-reveal-target="button"
               data-action="reveal#toggle">🔰 初めての方へ</button>
     </div>
@@ -70,5 +66,10 @@
       <div class="text-sm text-slate-500">最終ログイン</div>
       <div class="col-span-2"><%= current_user.last_login_at ? l(current_user.last_login_at, format: :ymd_hm) : "-" %></div>
     </div>
+  </div>
+
+  <div class="flex items-center justify-end">
+    <%= link_to "編集", edit_profile_path,
+          class: "btn-change is-edit" %>
   </div>
 </div>

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -15,7 +15,7 @@
   data-reveal-close-label-value="🔰 説明を閉じる">
   <div class="flex justify-end">
     <button type="button"
-            class="px-3 py-1 rounded ring-1 ring-slate-300 text-sm"
+            class="btn-toggle"
             data-reveal-target="button"
             data-action="reveal#toggle">🔰 初めての方へ</button>
   </div>

--- a/app/views/quizzes/sections/questions/answer.html.erb
+++ b/app/views/quizzes/sections/questions/answer.html.erb
@@ -4,30 +4,38 @@
 <% breadcrumb :quiz_question_answer_page, @quiz, @section, @question %>
 <%= render "shared/breadcrumbs" %>
 
-<% correct = (params[:choice].to_i == @question.correct_choice) %>
-<div class="rounded border p-4 bg-white" data-controller="code-highlight">
-  <p class="<%= correct ? 'text-emerald-700' : 'text-red-700' %> font-semibold">
-    <%= correct ? "正解！" : "不正解…" %>
-  </p>
-  <p class="mt-1 text-sm">正解：<%= @question.public_send("choice#{@question.correct_choice}") %></p>
+<div class="mx-auto w-full max-w-3xl pt-2 px-4 md:px-6 lg:px-8" data-controller="code-highlight">
+  <% correct = (params[:choice].to_i == @question.correct_choice) %>
+  <div class="rounded ring-1 ring-slate-200 p-4 space-y-3 bg-white">
+    <p class="<%= correct ? 'text-emerald-700' : 'text-red-700' %> font-semibold text-3xl text-center">
+      <%= correct ? "正解！" : "不正解…" %>
+    </p>
+    <p class="mt-1 text-lg font-semibold text-center">正解：<%= @question.public_send("choice#{@question.correct_choice}") %></p>
 
-  <div class="mt-3 p-3 rounded bg-slate-50 content-body">
-    <h3 class="font-semibold mb-1">解説</h3>
-    <div><%= rich_html(@question.explanation) %></div>
+    <div class="mt-3 p-3 rounded bg-slate-50">
+      <h3 class="text-xl font-semibold mb-1">解説</h3>
+      <article class="content-body prose break-all md:break-words">
+        <%= rich_html(@question.explanation) %>
+      </article>
+    </div>
+
+    <div class="mt-4 flex justify-end">
+      <% if @next_q %>
+        <%= link_to "NEXT ＞",
+              quiz_section_question_path(@quiz, @section, @next_q),
+              class: "btn-pill is-mint" %>
+      <% else %>
+        <%= link_to "結果を見る ＞",
+              result_quiz_section_path(@quiz, @section),
+              class: "btn-pill is-orange" %>
+      <% end %>
+    </div>
   </div>
 
-  <div class="flex justify-between mt-4">
-    <% if @next_q %>
-      <%= link_to "次の問題へ →", quiz_section_question_path(@quiz, @section, @next_q), class: "underline" %>
-    <% else %>
-      <%= link_to "結果を見る", result_quiz_section_path(@quiz, @section), class: "underline" %>
-    <% end %>
-  </div>
+  <% if can_edit?(@question) %>
+    <div class="flex justify-end my-3">
+      <%= link_to "この問題を編集", edit_quiz_section_question_path(@quiz, @section, @question),
+            class: "btn-change is-edit" %>
+    </div>
+  <% end %>
 </div>
-
-<% if can_edit?(@question) %>
-  <div class="mb-3">
-    <%= link_to "この問題を編集", edit_quiz_section_question_path(@quiz, @section, @question),
-          class: "inline-block px-3 py-1 rounded bg-slate-900 text-white text-sm" %>
-  </div>
-<% end %>

--- a/app/views/quizzes/sections/questions/edit.html.erb
+++ b/app/views/quizzes/sections/questions/edit.html.erb
@@ -53,8 +53,7 @@
     </div>
   </div>
 
-  <div>
-    <%= f.submit "更新する", class: "px-4 py-2 rounded bg-slate-900 text-white" %>
-    <%= link_to "戻る", quiz_section_question_path(@quiz, @section, @question), class: "ml-2 underline" %>
+  <div class="mt-6 flex justify-center">
+    <%= f.submit "更新する", class: "btn-solid-red--wide" %>
   </div>
 <% end %>

--- a/app/views/quizzes/sections/questions/show.html.erb
+++ b/app/views/quizzes/sections/questions/show.html.erb
@@ -4,43 +4,39 @@
 <% breadcrumb :quiz_question, @quiz, @section, @question %>
 <%= render "shared/breadcrumbs" %>
 
-<% content_for :title, "#{@section.heading} - 問題" %>
-<p class="text-sm text-slate-500 mb-2">
-  <%= link_to @quiz.title, quiz_path(@quiz) %> / <%= @section.heading %>
-</p>
+<div class="mx-auto w-full max-w-3xl pt-2 px-4 md:px-6 lg:px-8" data-controller="code-highlight">
+  <% content_for :title, "#{@section.heading} - 問題" %>
+  <p class="text-sm text-slate-500 mb-2">
+    <%= link_to @quiz.title, quiz_path(@quiz) %> / <%= @section.heading %>
+  </p>
 
-<div class="rounded border p-4 bg-white" data-controller="code-highlight">
-  <p class="text-slate-500 text-sm mb-1">Q<%= @question.position %></p>
+  <div class="rounded ring-1 ring-slate-200 p-4 bg-white">
+    <p class="text-slate-500 text-xl">Q<%= @question.position %></p>
 
-  <!-- 問題文（リッチ表示） -->
-  <h2 class="text-lg font-semibold mb-3 content-body">
-    <%= rich_html(@question.question) %>
-  </h2>
+    <!-- 問題文（リッチ表示） -->
+    <article class="content-body prose break-all w-full md:break-words">
+      <%= rich_html(@question.question) %>
+    </article>
 
-  <%= form_with url: answer_quiz_section_question_path(@quiz, @section, @question),
-                method: :post,
-                data: { turbo: false },
-                authenticity_token: true,
-                local: true,
-                class: "space-y-2" do %>
+    <!-- ▼ 各選択肢を“押した瞬間に送信”するボタンに変更 -->
+    <div class="space-y-2 pt-2">
+      <% (1..4).each do |i| %>
+        <% label = @question.public_send("choice#{i}") %>
+        <%= button_to label,
+              answer_quiz_section_question_path(@quiz, @section, @question),
+              params: { choice: i },
+              method: :post,
+              form: { data: { turbo: false } },
+              class: "btn-choice w-full text-left" %>
+      <% end %>
+    </div>
+  </div>
 
-    <% (1..4).each do |i| %>
-      <% label = @question.public_send("choice#{i}") %>
-      <label class="block">
-        <%= radio_button_tag :choice, i, false, required: true %>
-        <span class="ml-2"><%= label %></span>
-      </label>
-    <% end %>
-
-    <div class="mt-3">
-      <%= submit_tag "この回答で送信", class: "px-4 py-2 rounded bg-[#CC0000] text-white" %>
+  <% if can_edit?(@question) %>
+    <div class="flex justify-end my-3">
+      <%= link_to "この問題を編集",
+            edit_quiz_section_question_path(@quiz, @section, @question),
+            class: "btn-change is-edit" %>
     </div>
   <% end %>
 </div>
-
-<% if can_edit?(@question) %>
-  <div class="mb-3">
-    <%= link_to "この問題を編集", edit_quiz_section_question_path(@quiz, @section, @question),
-          class: "inline-block px-3 py-1 rounded bg-slate-900 text-white text-sm" %>
-  </div>
-<% end %>

--- a/app/views/quizzes/sections/result.html.erb
+++ b/app/views/quizzes/sections/result.html.erb
@@ -4,65 +4,67 @@
 <% breadcrumb :quiz_section_result, @quiz, @section %>
 <%= render "shared/breadcrumbs" %>
 
-<% content_for :title, "#{@section.heading} - 結果" %>
+<div class="mx-auto w-full max-w-3xl pt-2 px-4 md:px-6 lg:px-8">
+  <% content_for :title, "#{@section.heading} - 結果" %>
 
-<h1 class="text-2xl font-semibold mb-2"><%= @section.heading %> の結果</h1>
-<p class="text-xl mb-4">
-  <span class="font-bold"><%= @correct %></span> / <%= @total %> 正解
-</p>
+  <h1 class="text-2xl font-semibold mb-2"><%= @section.heading %> の結果</h1>
+  <p class="text-2xl text-center text-red-500 pt-3 mb-4">
+    <span class="font-bold"><%= @correct %> / <%= @total %>問 正解</span>
+  </p>
 
-<%# ===== 正答率に応じた 画像 + メッセージ ===== %>
-<%
-  percent = @total.to_i.positive? ? (@correct.to_f / @total) : 0.0
+  <%# ===== 正答率に応じた 画像 + メッセージ ===== %>
+  <%
+    percent = @total.to_i.positive? ? (@correct.to_f / @total) : 0.0
 
-  if @total.to_i.positive? && @correct == @total
-    msg = "おめでとう！！全問正解だよ！！"
-    img = "全問正解.png"
-  elsif percent >= 0.8
-    msg = "おしい！あと少しだ！！Fight！！！"
-    img = "８割以上.png"
-  elsif percent >= 0.6
-    msg = "まずまずと言ったところ… もう少しテキストの内容を理解しよう！！"
-    img = "６割以上.png"
-  elsif percent >= 0.3
-    msg = "不正解が多いね… もう一度テキストを読み直そう！"
-    img = "３割以上.png"
-  else
-    msg = "不正解がかなり多いね… もう一度テキストを読み直そう！"
-    img = "３割未満.png"
-  end
-%>
+    if @total.to_i.positive? && @correct == @total
+      msg = "おめでとう！！全問正解だよ！！"
+      img = "全問正解.png"
+    elsif percent >= 0.8
+      msg = "おしい！あと少しだ！！Fight！！！"
+      img = "８割以上.png"
+    elsif percent >= 0.6
+      msg = "まずまずと言ったところ… もう少しテキストの内容を理解しよう！！"
+      img = "６割以上.png"
+    elsif percent >= 0.3
+      msg = "不正解が多いね… もう一度テキストを読み直そう！"
+      img = "３割以上.png"
+    else
+      msg = "不正解がかなり多いね… もう一度テキストを読み直そう！"
+      img = "３割未満.png"
+    end
+  %>
 
-<div class="mb-6">
-  <div class="flex flex-col items-center gap-4">
-    <p class="text-lg font-semibold text-slate-800 text-center"><%= msg %></p>
-    <%= image_tag img, alt: msg, class: "max-w-full rounded shadow-sm w-full md:w-3/4" %>
+  <div class="mb-4">
+    <div class="flex flex-col items-center gap-2">
+      <p class="text-lg font-semibold text-slate-800 text-center"><%= msg %></p>
+      <%= image_tag img, alt: msg, class: "max-w-full rounded shadow-sm w-full md:w-3/4" %>
+    </div>
   </div>
-</div>
 
-<div class="flex justify-center mt-6"
-     data-controller="share"
-     data-share-url-value="<%= quizzes_url %>">
-  <button type="button"
-          data-action="share#openTwitter"
-          data-text="<%= "Rails Learning クイズで #{@correct}/#{@total} を獲得！ #RailsLearning" %>"
-          class="btn-dark">
-    Xでシェア
-  </button>
-</div>
-
-<div class="flex gap-3 mt-4">
-  <%= link_to "もう一度解く", quiz_section_path(@quiz, @section), class: "px-4 py-2 rounded ring-1 ring-slate-300" %>
-  <%= link_to "セクション一覧へ戻る", quiz_path(@quiz), class: "px-4 py-2 rounded ring-1 ring-slate-300" %>
-</div>
-
-<% if @section.book_section.present? %>
-  <div class="mt-8 p-5 rounded-xl ring-1 ring-slate-200 bg-white">
-    <p class="text-lg font-semibold mb-2">もう一度、テキストを読み直す？</p>
-    <p class="text-slate-600 mb-4">このクイズで出題された内容に対応するテキストへ戻れます。</p>
-
-    <%= link_to "Rails Booksへ",
-          book_section_path(@section.book_section.book, @section.book_section),
-          class: "inline-flex items-center rounded-md bg-slate-900 px-5 py-2 text-white hover:bg-black" %>
+  <div class="flex justify-center mt-2"
+      data-controller="share"
+      data-share-url-value="<%= quizzes_url %>">
+    <button type="button"
+            data-action="share#openTwitter"
+            data-text="<%= "Rails Learning クイズで #{@correct}/#{@total} を獲得！ #RailsLearning" %>"
+            class="btn-dark">
+      Xでシェア
+    </button>
   </div>
-<% end %>
+
+  <div class="mt-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+    <%= link_to "＜ セクション一覧へ戻る", quiz_path(@quiz), class: "btn-pill is-mint" %>
+    <%= link_to "もう一度解く ＞", quiz_section_path(@quiz, @section), class: "btn-pill is-mint" %>
+  </div>
+
+  <% if @section.book_section.present? %>
+    <div class="mt-3 p-5 rounded-xl ring-1 ring-slate-200 bg-white text-center">
+      <p class="text-lg font-semibold mb-2">もう一度、テキストを読み直す？</p>
+      <p class="text-slate-600 mb-4">このクイズで出題された内容に対応するテキストへ戻れます。</p>
+
+      <%= link_to "Rails Booksへ",
+            book_section_path(@section.book_section.book, @section.book_section),
+            class: "btn-pill is-red" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_modal_panel.html.erb
+++ b/app/views/shared/_modal_panel.html.erb
@@ -64,6 +64,7 @@
         <ul class="space-y-0 border-b-2 border-[#CC0000] divide-y-2 divide-[#CC0000]">
           <li><%= link_to "Code Editor",  editor_path,         class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "Rails Books",  books_path,          class: "block py-3 text-center hover:text-[#CC0000]" %></li>
+          <li><%= link_to "Quizzes",    quizzes_path,          class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "PreCode",      pre_codes_path,      class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "Code Library", code_libraries_path, class: "block py-3 text-center hover:text-[#CC0000]" %></li>
         </ul>
@@ -90,6 +91,7 @@
         <ul class="mt-2 border-b-2 border-[#CC0000] divide-y-2 divide-[#CC0000]">
           <li><%= link_to "Code Editor",  editor_path,         class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "Rails Books",  books_path,          class: "block py-3 text-center hover:text-[#CC0000]" %></li>
+          <li><%= link_to "Quizzes",    quizzes_path,          class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "PreCode",      pre_codes_path,      class: "block py-3 text-center hover:text-[#CC0000]" %></li>
           <li><%= link_to "Code Library", code_libraries_path, class: "block py-3 text-center hover:text-[#CC0000]" %></li>
         </ul>

--- a/app/views/shared/_tag_filter.html.erb
+++ b/app/views/shared/_tag_filter.html.erb
@@ -12,12 +12,12 @@
     <input type="hidden" name="tags" value="<%= params[:tags].to_s %>"
            data-tag-picker-target="hiddenInput">
 
-    <button type="button" class="px-3 py-2 rounded ring-1 ring-slate-300"
+    <button type="button" class="btn-bg-white"
             data-action="tag-picker#open">
       タグを選ぶ
     </button>
 
-    <button type="submit" class="px-3 py-2 rounded bg-[#CC0000] text-white hover:bg-[#BB0000] active:bg-[#AA0000]">
+    <button type="submit" class="btn-solid-red">
       検索
     </button>
   <% end %>

--- a/app/views/static_pages/help.html.erb
+++ b/app/views/static_pages/help.html.erb
@@ -67,7 +67,7 @@
       <% unless logged_in? %>
         <div class="pb-5 mt-3 flex justify-center">
           <%= link_to "このページへ移動する", new_user_path,
-            class: "inline-flex items-center justify-center px-6 py-2 rounded-full ring-1 ring-[#CC0000] text-[#CC0000] bg-white hover:bg-[#CC0000] hover:text-white active:bg-[#FFD6FF] transition-colors" %>
+            class: "btn-pill is-red" %>
         </div>
       <% end %>
     </details>
@@ -101,7 +101,7 @@
 
       <div class="pb-5 mt-3 flex justify-center">
         <%= link_to "このページへ移動する", code_libraries_path,
-            class: "inline-flex items-center justify-center px-6 py-2 rounded-full ring-1 ring-[#CC0000] text-[#CC0000] bg-white hover:bg-[#CC0000] hover:text-white active:bg-[#FFD6FF] transition-colors" %>
+            class: "btn-pill is-red" %>
       </div>
     </details>
 
@@ -133,7 +133,7 @@
 
       <div class="pb-5 mt-3 flex justify-center">
         <%= link_to "このページへ移動する", pre_codes_path,
-            class: "inline-flex items-center justify-center px-6 py-2 rounded-full ring-1 ring-[#CC0000] text-[#CC0000] bg-white hover:bg-[#CC0000] hover:text-white active:bg-[#FFD6FF] transition-colors" %>
+            class: "btn-pill is-red" %>
       </div>
     </details>
 
@@ -218,7 +218,7 @@
       <% unless logged_in? %>
         <div class="pb-5 mt-3 flex justify-center">
           <%= link_to "このページへ移動する", new_user_path,
-            class: "inline-flex items-center justify-center px-6 py-2 rounded-full ring-1 ring-[#CC0000] text-[#CC0000] bg-white hover:bg-[#CC0000] hover:text-white active:bg-[#FFD6FF] transition-colors" %>
+            class: "btn-pill is-red" %>
         </div>
       <% end %>
     </details>
@@ -251,7 +251,7 @@
 
       <div class="pb-5 mt-3 flex justify-center">
         <%= link_to "このページへ移動する", books_path,
-            class: "inline-flex items-center justify-center px-6 py-2 rounded-full ring-1 ring-[#CC0000] text-[#CC0000] bg-white hover:bg-[#CC0000] hover:text-white active:bg-[#FFD6FF] transition-colors" %>
+            class: "btn-pill is-red" %>
       </div>
     </details>
 
@@ -282,7 +282,7 @@
 
       <div class="pb-5 mt-3 flex justify-center">
         <%= link_to "このページへ移動する", books_path,
-            class: "inline-flex items-center justify-center px-6 py-2 rounded-full ring-1 ring-[#CC0000] text-[#CC0000] bg-white hover:bg-[#CC0000] hover:text-white active:bg-[#FFD6FF] transition-colors" %>
+            class: "btn-pill is-red" %>
       </div>
     </details>
 
@@ -375,7 +375,7 @@
 
       <div class="pb-5 mt-3 flex justify-center">
         <%= link_to "このページへ移動する", books_path,
-            class: "inline-flex items-center justify-center px-6 py-2 rounded-full ring-1 ring-[#CC0000] text-[#CC0000] bg-white hover:bg-[#CC0000] hover:text-white active:bg-[#FFD6FF] transition-colors" %>
+            class: "btn-pill is-red" %>
       </div>
     </details>
 
@@ -406,7 +406,7 @@
 
       <div class="pb-5 mt-3 flex justify-center">
         <%= link_to "このページへ移動する", editor_path,
-            class: "inline-flex items-center justify-center px-6 py-2 rounded-full ring-1 ring-[#CC0000] text-[#CC0000] bg-white hover:bg-[#CC0000] hover:text-white active:bg-[#FFD6FF] transition-colors" %>
+            class: "btn-pill is-red" %>
       </div>
     </details>
 
@@ -439,7 +439,7 @@
 
       <div class="pb-5 mt-3 flex justify-center">
         <%= link_to "このページへ移動する", pre_codes_path,
-            class: "inline-flex items-center justify-center px-6 py-2 rounded-full ring-1 ring-[#CC0000] text-[#CC0000] bg-white hover:bg-[#CC0000] hover:text-white active:bg-[#FFD6FF] transition-colors" %>
+            class: "btn-pill is-red" %>
       </div>
     </details>
 
@@ -472,7 +472,7 @@
 
       <div class="pb-5 mt-3 flex justify-center">
         <%= link_to "このページへ移動する", code_libraries_path,
-            class: "inline-flex items-center justify-center px-6 py-2 rounded-full ring-1 ring-[#CC0000] text-[#CC0000] bg-white hover:bg-[#CC0000] hover:text-white active:bg-[#FFD6FF] transition-colors" %>
+            class: "btn-pill is-red" %>
       </div>
     </details>
   </section>
@@ -580,7 +580,7 @@
     </p>
     <div class="mt-4 flex justify-center">
       <%= link_to "お問い合わせ", contact_path,
-            class: "inline-flex items-center justify-center px-6 py-2 rounded-full ring-1 ring-[#CC0000] text-[#CC0000] bg-white hover:bg-[#CC0000] hover:text-white active:bg-[#FFD6FF] transition-colors" %>
+            class: "btn-pill is-red" %>
     </div>
   </section>
 </div>


### PR DESCRIPTION
### 概要
初心者向けの導線を全画面に整備し（🔰 初めての方へ）、クイズ結果の視認性・管理UIの操作性・運用通知（編集/問い合わせメール）を横断的に改善した。

**作業内容**
- reveal_controller を開閉ラベル対応に拡張し、各画面タイトル直下に「🔰 初めての方へ」ブロックを右寄せで配置（文章は指定どおり原文をそのまま埋込）
- Code Editor / Rails Books / Quizzes / PreCodes / Code Library / Profile(表示・編集) に説明セクションを追加し、既存の表示/検索UIと干渉しないようスタイル調整
- クイズ結果画面に正答率で変わるメッセージ＆画像を実装し、共有導線と復習導線（Booksへの戻り）を追加
- 管理画面ヘッダー（ナビ/ドロップダウン/モーダル）を再構成して操作経路を整理、レイアウトを統一
- 編集/問い合わせのダイジェストメール・ジョブ/タスク/whenever設定・dev用letter_opener等の運用基盤を追加（Dockerfile/環境変数/ルーティング含む）