### PR TITLE
Google Analytics 4導入：環境変数設定・計測スクリプト追加・Turbo対応・CSP許可設定を実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,5 @@ JUDGE0_HOST_HEADER=
 
 GOOGLE_FORM_URL=iframe用のGoogleフォームURL
 GOOGLE_FORM_CONFIRM_URL=Googleフォームの問い合わせページに直接アクセスするためのURL
+
+GA_MEASUREMENT_ID=Google_Analyticsの測定ID

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,9 @@
     <%= csp_meta_tag %>
     <%= yield :head %>
 
+    <%# ===== Google Analytics ===== %>
+    <%= render "shared/google_analytics" %>
+
     <%# ===== アイコン & PWA ===== %>
     <%= favicon_link_tag 'favicon.ico', rel: 'icon', type: 'image/x-icon' %>
     <link rel="manifest" href="/manifest.json">

--- a/app/views/shared/_google_analytics.html.erb
+++ b/app/views/shared/_google_analytics.html.erb
@@ -1,0 +1,35 @@
+<%# Google Analytics (gtag.js) - 本番かつ GA_MEASUREMENT_ID があるときだけ有効化 %>
+<% if Rails.env.production? && ENV["GA_MEASUREMENT_ID"].present? %>
+  <% ga_id = ENV["GA_MEASUREMENT_ID"] %>
+
+  <!-- Global site tag (gtag.js) -->
+  <script async
+          src="https://www.googletagmanager.com/gtag/js?id=<%= ERB::Util.url_encode(ga_id) %>"
+          nonce="<%= content_security_policy_nonce %>"></script>
+
+  <script nonce="<%= content_security_policy_nonce %>">
+    // dataLayer の初期化
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+    gtag('js', new Date());
+
+    // 初期の自動 page_view はオフ（SPA/Turbo で自前送信するため）
+    gtag('config', '<%= ga_id %>', { 'send_page_view': false });
+
+    // ページ表示イベントを明示送信（タイトル/URL/クエリ含む）
+    function sendPageView() {
+      gtag('event', 'page_view', {
+        page_title:   document.title,
+        page_location: location.href,
+        page_path:     location.pathname + location.search
+      });
+    }
+
+    // Turbo あり: 画面遷移ごとに送信
+    document.addEventListener('turbo:load', sendPageView);
+    // 念のため（Turbo 不使用ページ向け）
+    if (!window.Turbo) {
+      document.addEventListener('DOMContentLoaded', sendPageView);
+    }
+  </script>
+<% end %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,25 +1,18 @@
-# Be sure to restart your server when you modify this file.
+# 本番環境のみCSPを有効化し、Google Analytics 用の許可を追加
+if Rails.env.production?
+  require "securerandom"
 
-# Define an application-wide content security policy.
-# See the Securing Rails Applications Guide for more information:
-# https://guides.rubyonrails.org/security.html#content-security-policy-header
+  Rails.application.config.content_security_policy do |policy|
+    # 必要なディレクティブだけ追加（他は既定値のまま）
+    policy.script_src  :self, :https, "https://www.googletagmanager.com"
+    policy.connect_src :self, :https,
+                       "https://www.google-analytics.com",
+                       "https://www.googletagmanager.com"
+    policy.img_src     :self, :https, :data
+    policy.frame_src   :self, :https
+  end
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+  # インライン <script> を安全に許可するための nonce 設定
+  Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+  Rails.application.config.content_security_policy_nonce_directives = %w[script-src]
+end


### PR DESCRIPTION
### 概要
Google Analytics 4（GA4）をRails Learningに導入し、ページビューや遷移を自動計測できるようにした。

**作業内容**
- Google Analyticsプロパティを作成し、Renderおよび.envに測定ID（GA_MEASUREMENT_ID）を設定
- `app/views/shared/_google_analytics.html.erb` を新規追加し、Turbo遷移対応のgtag埋め込みを実装
- `application.html.erb` に共通パーシャルを読み込み、全ページで計測可能に
- `content_security_policy.rb` にGoogle Analytics関連の許可ドメインを追加（gtag/analytics用）
- 本番環境限定での動作制御を導入し、開発環境では無効化