### PR TITLE
管理者通知ジョブ修正：PaperTrail require削除とジョブ安定化（LoadError対応）

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,7 +320,7 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.3)
-    rack-protection (4.1.1)
+    rack-protection (4.2.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)

--- a/app/controllers/admin/versions_controller.rb
+++ b/app/controllers/admin/versions_controller.rb
@@ -12,9 +12,6 @@
 # - 管理対象は ALLOWED_ITEM_TYPES でホワイトリスト化
 # - reify 時の JSON/YAML 差異・非許可クラスに安全に対応 (safe_reify/permit_yaml_classes!)
 # - ロールバック時は一時的に楽観ロックを解除 (toggle_lock) して保存整合を取りやすく
-#
-# ■ 注意
-# - ここでは「コメント追加と並び替え」のみ行い、挙動は変更していません。
 # ============================================================
 class Admin::VersionsController < Admin::BaseController
   layout "admin"

--- a/app/jobs/hourly_digest_job.rb
+++ b/app/jobs/hourly_digest_job.rb
@@ -29,12 +29,14 @@ class HourlyDigestJob < ApplicationJob
   # PaperTrail 更新通知メール
   # =======================
   def send_edits_digest(window_start:, window_end:)
-    require "paper_trail/version"
+    # 必要なら下行のように gem 本体を明示的に require する（通常は不要）
+    # require "paper_trail"
 
     versions = PaperTrail::Version
                  .where(event: "update", created_at: window_start..window_end)
                  .where(item_type: %w[BookSection QuizQuestion])
                  .order(:created_at)
+
     return if versions.blank?
 
     edits = versions.map do |v|
@@ -69,7 +71,7 @@ class HourlyDigestJob < ApplicationJob
   # =======================
   def send_contact_digest(window_start:, window_end:)
     count = fetch_google_form_count(window_start:, window_end:)
-    return if count == 0
+    return if count.to_i == 0
     AdminDigestMailer.contact_digest(count:, window_start:, window_end:).deliver_now
   end
 


### PR DESCRIPTION
### 概要
毎時の管理者向け通知ジョブ（HourlyDigestJob）で発生していた LoadError（paper_trail/version）を修正し、PaperTrail v17 に準拠した安全な実装に変更した。

**作業内容**

- 不要かつ存在しない `require "paper_trail/version"` を削除（PaperTrail v17以降はautoload対応のため）
- digest:window タスクによる動作確認（構文・ロジック・ジョブ動作とも正常）
- Cron Job 側は変更していない（既存設定でジョブが正常実行されることを確認）
