### PR TITLE
パスワードリセット機能を全ユーザー（外部連携含む）で利用可能に変更し、ユーザー存在は秘匿したまま開発環境でのみ非送信理由をログ出力するよう改善

### DIFF
--- a/app/views/shared/_modal_panel.html.erb
+++ b/app/views/shared/_modal_panel.html.erb
@@ -77,6 +77,12 @@
           <li><%= link_to "プライバシーポリシー", privacy_path, class: "block py-3 text-center hover:text-[#CC0000]" %></li>
         </ul>
 
+        <% if current_user&.admin? %>
+          <ul class="mt-2 border-b-2 border-[#CC0000] divide-y-2 divide-[#CC0000]">
+            <li><%= link_to "管理画面", admin_root_path, class: "block py-3 text-center hover:text-[#CC0000]" %></li>
+          </ul>
+        <% end %>
+
         <ul class="mt-2 border-b-2 border-[#CC0000] divide-y-2 divide-[#CC0000]">
           <li><%= link_to "ログアウト", session_path,
                 data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" },


### PR DESCRIPTION
### 目的
公開のパスワードリセットフォームを、外部連携ユーザーも含めた全ユーザーで利用可能にする。
ユーザー存在は従来どおり秘匿。

### 変更点
- PasswordResetsController#create の送信条件を「email一致ユーザーが存在するなら送信」に変更
- dev/test でのみ非送信理由の info ログを出力（prod は秘匿）
- ProfilesController など既存フローへの影響なし（無変更）

### 動作確認
- パスワード型/外部連携型ユーザーとも Letter Opener にメールが届く
- 未登録メールは送信されない（画面は秘匿メッセージ）