### PR TITLE
Code Library: いいね解除時にブックマークまでOFFになる不具合を修正（likes/destroy で current_boo…

### DIFF
--- a/app/views/code_libraries/_actions.html.erb
+++ b/app/views/code_libraries/_actions.html.erb
@@ -1,9 +1,13 @@
 <!-- app/views/code_libraries/_actions.html.erb -->
 <%# locals: pre_code:, current_like:, current_bookmark: %>
 
-<%# === local が渡ってこないケースでも nil を入れて落ちないように === %>
+<%# === 呼び出し側が渡し忘れても落ちない & なるべく正確に表示する === %>
 <% current_like     = local_assigns.fetch(:current_like, nil) %>
 <% current_bookmark = local_assigns.fetch(:current_bookmark, nil) %>
+<% if logged_in? %>
+  <% current_like     ||= pre_code.likes.find_by(user_id: current_user.id) %>
+  <% current_bookmark ||= pre_code.bookmarks.find_by(user_id: current_user.id) %>
+<% end %>
 
 <div id="<%= dom_id(pre_code, :actions) %>" class="flex gap-2">
   <% if logged_in? %>

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,9 +1,9 @@
-<!-- app/views/likes/destroy.turbo_stream.erb -->
+<!-- app/views/likes/create.turbo_stream.erb -->
 <%= turbo_stream.replace dom_id(@pre_code, :actions) do %>
   <%= render "code_libraries/actions",
       pre_code: @pre_code,
-      current_like:      (logged_in? ? @pre_code.likes.find_by(user_id: current_user.id)       : nil),
-      current_bookmark:  (logged_in? ? @pre_code.bookmarks.find_by(user_id: current_user.id)   : nil) %>
+      current_like:      (logged_in? ? @pre_code.likes.find_by(user_id: current_user.id)      : nil),
+      current_bookmark:  (logged_in? ? @pre_code.bookmarks.find_by(user_id: current_user.id)  : nil) %>
 <% end %>
 
 <%= turbo_stream.replace dom_id(@pre_code, :metrics) do %>

--- a/app/views/likes/destroy.turbo_stream.erb
+++ b/app/views/likes/destroy.turbo_stream.erb
@@ -2,7 +2,8 @@
 <%= turbo_stream.replace dom_id(@pre_code, :actions) do %>
   <%= render "code_libraries/actions",
         pre_code: @pre_code,
-        current_like: current_user.likes.find_by(pre_code_id: @pre_code.id) %>
+        current_like: (logged_in? ? @pre_code.likes.find_by(user_id: current_user.id) : nil),
+        current_bookmark: (logged_in? ? @pre_code.bookmarks.find_by(user_id: current_user.id) : nil) %>
 <% end %>
 
 <%= turbo_stream.replace dom_id(@pre_code, :metrics) do %>


### PR DESCRIPTION
### 目的
「いいね」と「ブックマーク」が同時ONの状態で、いいね解除時にブックマークまでOFF表示になる不具合を解消する。

### 変更点
- `likes/destroy.turbo_stream.erb` に `current_bookmark` を追加して `_actions` に正しい状態を渡す
- `likes/create.turbo_stream.erb` のローカル渡しを整理（記法統一）
- `_actions.html.erb` を自己補完可能にして、ローカル未指定でも現在状態を取得するよう堅牢化
- 既存コントローラ／モデル／ルーティングの変更なし、DB変更なし（互換）

### 動作確認
- 両方ON→「いいね」をOFFにしてもブックマークは維持されることを確認
- 両方ON→「ブックマーク」をOFFにしてもいいねは維持されることを確認
- 片方のみONの状態で各ボタンが単独にトグルすることを確認（カウンタも正しく増減）
- Turbo Stream/HTML 両方の応答でUIが正しく再描画されることを確認（リロード後も状態一致）