### PR TITLE
Books/Quiz管理: heading上限100へ拡張＋Ransack検索対応＋依存ドロップダウン実装（既存バリデーション/Paper…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", require: false
+  gem "brakeman", "~> 7.1.1", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.0)
+    brakeman (7.1.1)
       racc
     builder (3.3.0)
     bullet (8.1.0)
@@ -514,7 +514,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt
   bootsnap
-  brakeman
+  brakeman (~> 7.1.1)
   bullet
   capybara
   debug

--- a/app/controllers/admin/quiz_questions_controller.rb
+++ b/app/controllers/admin/quiz_questions_controller.rb
@@ -4,6 +4,7 @@
 # ・CRUD操作（一覧・作成・更新・削除）
 # ・保存前に Quill のHTMLを RichTextSanitizer でサニタイズ
 # ・クイズやセクションとのリレーションを includes で最適化
+# ・一覧は Ransack で quizzes.title / quiz_sections.heading を検索
 # ============================================================
 class Admin::QuizQuestionsController < Admin::BaseController
   layout "admin"
@@ -13,9 +14,12 @@ class Admin::QuizQuestionsController < Admin::BaseController
   # 一覧
   # =======================
   def index
-    @questions = QuizQuestion.includes(:quiz, :quiz_section)
-                             .order(created_at: :desc)
-                             .page(params[:page])
+    base = QuizQuestion.includes(:quiz, :quiz_section)
+    @q = base.ransack(params[:q])
+    @questions = @q.result
+                   .includes(:quiz, :quiz_section)
+                   .order(created_at: :desc)
+                   .page(params[:page])
   end
 
   # =======================

--- a/app/controllers/admin/quiz_sections_controller.rb
+++ b/app/controllers/admin/quiz_sections_controller.rb
@@ -3,6 +3,7 @@
 # ------------------------------------------------------------
 # ・クイズごとの章（セクション）管理
 # ・CRUD実装のみ（単純構造）
+# ・一覧は Ransack で quizzes.title / quiz_sections.heading を検索
 # ============================================================
 class Admin::QuizSectionsController < Admin::BaseController
   layout "admin"
@@ -11,9 +12,9 @@ class Admin::QuizSectionsController < Admin::BaseController
   # 一覧
   # =======================
   def index
-    @sections = QuizSection.includes(:quiz)
-                           .order(updated_at: :desc)
-                           .page(params[:page])
+    base = QuizSection.includes(:quiz)
+    @q = base.ransack(params[:q])
+    @sections = @q.result.includes(:quiz).order(updated_at: :desc).page(params[:page])
   end
 
   # =======================
@@ -46,6 +47,15 @@ class Admin::QuizSectionsController < Admin::BaseController
   def destroy
     QuizSection.find(params[:id]).destroy
     redirect_to admin_quiz_sections_path, notice: "削除しました"
+  end
+
+  # =======================
+  # 依存ドロップダウン用: Quiz に紐づくセクション一覧を返す
+  # GET /admin/quiz_sections/options?quiz_id=1
+  # =======================
+  def options
+    sections = QuizSection.where(quiz_id: params[:quiz_id]).order(:position)
+    render json: sections.select(:id, :heading).map { |s| { id: s.id, text: s.heading } }
   end
 
   private

--- a/app/javascript/controllers/quiz_form_controller.js
+++ b/app/javascript/controllers/quiz_form_controller.js
@@ -1,0 +1,52 @@
+// ============================================================
+// Stimulus: quiz-form
+// ------------------------------------------------------------
+// Quiz の選択に応じて QuizSection のプルダウンを絞り込む。
+// ルーティング: GET /admin/quiz_sections/options?quiz_id=:id
+// 返却JSON: [{ id: number, text: string }, ...]
+// ============================================================
+
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["quiz", "section"]
+
+  connect() {
+    // 画面初期表示時にも Quiz に紐づく Section だけを表示
+    this.onQuizChange()
+  }
+
+  async onQuizChange() {
+    const quizId = this.quizTarget.value
+    if (!quizId) return
+
+    try {
+      const res = await fetch(`/admin/quiz_sections/options?quiz_id=${encodeURIComponent(quizId)}`, {
+        headers: { "Accept": "application/json" },
+        credentials: "same-origin"
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const items = await res.json() // [{id, text}]
+      this.replaceSectionOptions(items)
+    } catch (e) {
+      console.error("[quiz-form] failed to load sections:", e)
+    }
+  }
+
+  replaceSectionOptions(items) {
+    const current = this.sectionTarget.value
+    this.sectionTarget.innerHTML = ""
+
+    items.forEach(({ id, text }) => {
+      const opt = document.createElement("option")
+      opt.value = String(id)
+      opt.textContent = text
+      this.sectionTarget.appendChild(opt)
+    })
+
+    // 既存値が同一 Quiz 内にあれば選択を維持
+    if (current && Array.from(this.sectionTarget.options).some(o => o.value === current)) {
+      this.sectionTarget.value = current
+    }
+  }
+}

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -30,6 +30,17 @@ class Book < ApplicationRecord
   # =======================
   before_validation :set_default_position, on: :create
 
+  # =======================
+  # Ransack 許可
+  # =======================
+  def self.ransackable_attributes(_auth = nil)
+    %w[title]
+  end
+
+  def self.ransackable_associations(_auth = nil)
+    %w[book_sections]
+  end
+
   private
 
   # 連番付与（最大position+1）

--- a/app/models/book_section.rb
+++ b/app/models/book_section.rb
@@ -20,7 +20,7 @@ class BookSection < ApplicationRecord
   # =======================
   # バリデーション
   # =======================
-  validates :heading, presence: true, length: { maximum: 50 }
+  validates :heading, presence: true, length: { maximum: 100 }
   validates :content, presence: true, length: { maximum: 30_000 }
   validates :position,
            presence: true,
@@ -54,6 +54,19 @@ class BookSection < ApplicationRecord
   # =======================
   def editable_attributes
     %i[content]
+  end
+
+  # =======================
+  # Ransack 許可
+  # -----------------------
+  # 管理画面の検索で使うカラム・関連をホワイトリスト化
+  # =======================
+  def self.ransackable_attributes(_auth = nil)
+    %w[heading position created_at updated_at]
+  end
+
+  def self.ransackable_associations(_auth = nil)
+    %w[book]
   end
 
   private

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -30,6 +30,19 @@ class Quiz < ApplicationRecord
   # =======================
   before_validation :set_default_position, on: :create
 
+  # =======================
+  # Ransack 設定（検索許可）
+  # -----------------------
+  # 管理画面の検索で許可する属性/関連をホワイトリスト化
+  # =======================
+  def self.ransackable_attributes(_auth = nil)
+    %w[title]
+  end
+
+  def self.ransackable_associations(_auth = nil)
+    %w[quiz_sections quiz_questions]
+  end
+
   private
 
   # 連番付与（最大position+1）

--- a/app/models/quiz_question.rb
+++ b/app/models/quiz_question.rb
@@ -42,4 +42,17 @@ class QuizQuestion < ApplicationRecord
   def editable_attributes
     %i[question choice1 choice2 choice3 choice4 correct_choice explanation]
   end
+
+  # =======================
+  # Ransack 設定（検索許可）
+  # -----------------------
+  # quizzes.title / quiz_sections.heading での検索に必要
+  # =======================
+  def self.ransackable_attributes(_auth = nil)
+    %w[question position correct_choice created_at updated_at]
+  end
+
+  def self.ransackable_associations(_auth = nil)
+    %w[quiz quiz_section]
+  end
 end

--- a/app/models/quiz_section.rb
+++ b/app/models/quiz_section.rb
@@ -37,4 +37,17 @@ class QuizSection < ApplicationRecord
   # =======================
   def previous = quiz.quiz_sections.where("position < ?", position).order(position: :desc).first
   def next     = quiz.quiz_sections.where("position > ?", position).order(position: :asc).first
+
+  # =======================
+  # Ransack 設定（検索許可）
+  # -----------------------
+  # quizzes.title / quiz_sections.heading での検索に必要
+  # =======================
+  def self.ransackable_attributes(_auth = nil)
+    %w[heading position created_at updated_at]
+  end
+
+  def self.ransackable_associations(_auth = nil)
+    %w[quiz book_section quiz_questions]
+  end
 end

--- a/app/views/admin/book_sections/index.html.erb
+++ b/app/views/admin/book_sections/index.html.erb
@@ -2,8 +2,21 @@
 <%= render "shared/breadcrumbs" %>
 
 <h1 class="text-2xl font-semibold mb-4">Sections</h1>
-<div class="mb-4">
+
+<div class="mb-4 flex items-center justify-between gap-3">
   <%= link_to "新規作成", new_admin_book_section_path, class: "px-3 py-2 rounded bg-slate-900 text-white" %>
+
+  <!-- ▼ 検索フォーム（Book.title / heading） -->
+  <div>
+    <%= search_form_for @q, url: admin_book_sections_path, method: :get, html: { class: "flex gap-2" } do |f| %>
+      <%= f.search_field :book_title_cont,  placeholder: "Bookタイトルを含む",  class: "px-3 py-2 rounded ring-1 ring-slate-300 w-56" %>
+      <%= f.search_field :heading_cont,     placeholder: "セクション見出しを含む", class: "px-3 py-2 rounded ring-1 ring-slate-300 w-64" %>
+      <%= f.submit "検索", class: "px-3 py-2 rounded bg-slate-900 text-white" %>
+      <% if params[:q].present? %>
+        <%= link_to "クリア", admin_book_sections_path, class: "px-3 py-2 rounded ring-1 ring-slate-300" %>
+      <% end %>
+    <% end %>
+  </div>
 </div>
 
 <table class="w-full text-left border bg-white">
@@ -33,3 +46,6 @@
     <% end %>
   </tbody>
 </table>
+
+<!-- ▼ ページネーション -->
+<div class="mt-4"><%= paginate @sections if respond_to?(:paginate) %></div>

--- a/app/views/admin/quiz_questions/_form.html.erb
+++ b/app/views/admin/quiz_questions/_form.html.erb
@@ -2,7 +2,9 @@
               url: (@question.new_record? ? admin_quiz_questions_path : admin_quiz_question_path(@question)),
               method: (@question.new_record? ? :post : :patch),
               local: true,
-              class: "space-y-4" do |f| %>
+              class: "space-y-4",
+              data: { controller: "quiz-form" } do |f| %>
+
   <% if @question.errors.any? %>
     <div class="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">
       <p><strong><%= @question.errors.count %></strong> 件のエラーがあります：</p>
@@ -12,18 +14,24 @@
     </div>
   <% end %>
 
+  <!-- Quiz 選択（変更で Section を絞り込み） -->
   <div>
     <%= f.label :quiz_id, "Quiz", class: "block text-sm text-slate-600" %>
     <%= f.collection_select :quiz_id, Quiz.order(:position), :id, :title,
-          {}, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2",
-          data: { controller: "quiz-form" } %>
+          {},
+          class: "w-full rounded ring-1 ring-slate-300 px-3 py-2",
+          data: { "quiz-form-target": "quiz", action: "change->quiz-form#onQuizChange" } %>
   </div>
 
+  <!-- Section 選択（初期表示時も quiz に合わせて置換される） -->
   <div>
     <%= f.label :quiz_section_id, "Section", class: "block text-sm text-slate-600" %>
-    <%= f.collection_select :quiz_section_id, QuizSection.includes(:quiz).order("quizzes.position, quiz_sections.position"),
+    <%= f.collection_select :quiz_section_id,
+          QuizSection.includes(:quiz).order("quizzes.position, quiz_sections.position"),
           :id, ->(s){ "[#{s.quiz.title}] #{s.heading}" },
-          {}, class: "w-full rounded ring-1 ring-slate-300 px-3 py-2" %>
+          {},
+          class: "w-full rounded ring-1 ring-slate-300 px-3 py-2",
+          data: { "quiz-form-target": "section" } %>
   </div>
 
   <!-- ▼ 問題文（Quill） -->

--- a/app/views/admin/quiz_questions/index.html.erb
+++ b/app/views/admin/quiz_questions/index.html.erb
@@ -3,9 +3,19 @@
 
 <h1 class="text-xl font-bold mb-4">Quiz Questions</h1>
 
-<div class="mb-3">
+<div class="mb-3 flex items-center justify-between gap-3">
   <%= link_to "＋ 新規作成", new_admin_quiz_question_path,
         class: "px-3 py-2 rounded bg-slate-900 text-white" %>
+
+  <!-- ▼ 検索フォーム（Quiz.title / QuizSection.heading） -->
+  <%= search_form_for @q, url: admin_quiz_questions_path, method: :get, html: { class: "flex gap-2" } do |f| %>
+    <%= f.search_field :quiz_title_cont,           placeholder: "Quizタイトル", class: "px-3 py-2 rounded ring-1 ring-slate-300 w-52" %>
+    <%= f.search_field :quiz_section_heading_cont, placeholder: "Section見出し", class: "px-3 py-2 rounded ring-1 ring-slate-300 w-56" %>
+    <%= f.submit "検索", class: "px-3 py-2 rounded bg-slate-900 text-white" %>
+    <% if params[:q].present? %>
+      <%= link_to "クリア", admin_quiz_questions_path, class: "px-3 py-2 rounded ring-1 ring-slate-300" %>
+    <% end %>
+  <% end %>
 </div>
 
 <table class="w-full text-sm border rounded overflow-hidden">

--- a/app/views/admin/quiz_sections/index.html.erb
+++ b/app/views/admin/quiz_sections/index.html.erb
@@ -3,9 +3,19 @@
 
 <h1 class="text-xl font-bold mb-4">Quiz Sections</h1>
 
-<div class="mb-3">
+<div class="mb-3 flex items-center justify-between gap-3">
   <%= link_to "＋ 新規作成", new_admin_quiz_section_path,
         class: "px-3 py-2 rounded bg-slate-900 text-white" %>
+
+  <!-- ▼ 検索フォーム（Quiz.title / heading） -->
+  <%= search_form_for @q, url: admin_quiz_sections_path, method: :get, html: { class: "flex gap-2" } do |f| %>
+    <%= f.search_field :quiz_title_cont, placeholder: "Quizタイトル", class: "px-3 py-2 rounded ring-1 ring-slate-300 w-52" %>
+    <%= f.search_field :heading_cont,    placeholder: "Section見出し", class: "px-3 py-2 rounded ring-1 ring-slate-300 w-56" %>
+    <%= f.submit "検索", class: "px-3 py-2 rounded bg-slate-900 text-white" %>
+    <% if params[:q].present? %>
+      <%= link_to "クリア", admin_quiz_sections_path, class: "px-3 py-2 rounded ring-1 ring-slate-300" %>
+    <% end %>
+  <% end %>
 </div>
 
 <table class="w-full text-sm border rounded overflow-hidden">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,10 +69,6 @@ Rails.application.routes.draw do
 
   # 管理画面
   namespace :admin do
-    get "editor_permissions/index"
-    get "editor_permissions/new"
-    get "editor_permissions/create"
-    get "editor_permissions/destroy"
     root "dashboards#index"
 
     resource  :session,   only: %i[new create destroy]
@@ -80,7 +76,10 @@ Rails.application.routes.draw do
     resources :book_sections, except: %i[show]
     resources :pre_codes, only: %i[index show edit update destroy]
     resources :quizzes
-    resources :quiz_sections
+    resources :quiz_sections do
+      # 依存ドロップダウン用
+      collection { get :options }
+    end
     resources :quiz_questions
 
     resources :users, only: [ :index, :destroy ] do

--- a/db/migrate/20251107050218_increase_book_sections_heading_limit_to100.rb
+++ b/db/migrate/20251107050218_increase_book_sections_heading_limit_to100.rb
@@ -1,0 +1,9 @@
+class IncreaseBookSectionsHeadingLimitTo100 < ActiveRecord::Migration[8.1]
+  def up
+    change_column :book_sections, :heading, :string, limit: 100, null: false
+  end
+
+  def down
+    change_column :book_sections, :heading, :string, limit: 50, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,29 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_09_180431) do
+ActiveRecord::Schema[8.1].define(version: 2025_11_07_050218) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum"
+    t.string "content_type"
     t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -43,11 +43,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_180431) do
   end
 
   create_table "authentications", force: :cascade do |t|
-    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
     t.string "provider", null: false
     t.string "uid", null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid", unique: true
     t.index ["user_id", "provider"], name: "index_authentications_on_user_id_and_provider", unique: true
     t.index ["user_id"], name: "index_authentications_on_user_id"
@@ -55,14 +55,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_180431) do
 
   create_table "book_sections", force: :cascade do |t|
     t.bigint "book_id", null: false
-    t.string "heading", limit: 50, null: false
     t.text "content", null: false
-    t.boolean "is_free", default: false, null: false
-    t.integer "position", null: false
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "heading", limit: 100, null: false
+    t.boolean "is_free", default: false, null: false
     t.integer "lock_version", default: 0, null: false
+    t.integer "position", null: false
     t.bigint "quiz_section_id"
+    t.datetime "updated_at", null: false
     t.index ["book_id", "position"], name: "index_book_sections_on_book_id_and_position", unique: true
     t.index ["book_id"], name: "index_book_sections_on_book_id"
     t.index ["quiz_section_id"], name: "index_book_sections_on_quiz_section_id"
@@ -71,53 +71,53 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_180431) do
   end
 
   create_table "bookmarks", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "pre_code_id", null: false
     t.datetime "created_at", null: false
+    t.bigint "pre_code_id", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["pre_code_id"], name: "index_bookmarks_on_pre_code_id"
     t.index ["user_id", "pre_code_id"], name: "index_bookmarks_on_user_id_and_pre_code_id", unique: true
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
   create_table "books", force: :cascade do |t|
-    t.string "title", limit: 100, null: false
-    t.text "description", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.integer "book_sections_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.text "description", null: false
     t.integer "position", null: false
+    t.string "title", limit: 100, null: false
+    t.datetime "updated_at", null: false
     t.index ["position"], name: "index_books_on_position", unique: true
     t.check_constraint "\"position\" > 0 AND \"position\" <= 9999", name: "books_position_range_chk"
     t.check_constraint "char_length(description) <= 1000", name: "books_description_len_chk"
   end
 
   create_table "editor_permissions", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "target_type", null: false
-    t.bigint "target_id", null: false
-    t.integer "role", default: 0, null: false
     t.datetime "created_at", null: false
+    t.integer "role", default: 0, null: false
+    t.bigint "target_id", null: false
+    t.string "target_type", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["target_type", "target_id"], name: "index_editor_permissions_on_target_type_and_target_id"
     t.index ["user_id", "target_type", "target_id"], name: "index_editor_permissions_on_user_and_target", unique: true
     t.index ["user_id"], name: "index_editor_permissions_on_user_id"
   end
 
   create_table "likes", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "pre_code_id", null: false
     t.datetime "created_at", null: false
+    t.bigint "pre_code_id", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["pre_code_id"], name: "index_likes_on_pre_code_id"
     t.index ["user_id", "pre_code_id"], name: "index_likes_on_user_id_and_pre_code_id", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
   create_table "pre_code_taggings", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.bigint "pre_code_id", null: false
     t.bigint "tag_id", null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["pre_code_id", "tag_id"], name: "index_pre_code_taggings_on_pre_code_id_and_tag_id", unique: true
     t.index ["pre_code_id"], name: "index_pre_code_taggings_on_pre_code_id"
@@ -125,17 +125,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_180431) do
   end
 
   create_table "pre_codes", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "title", limit: 50, null: false
-    t.text "description"
-    t.text "body", null: false
-    t.integer "like_count", default: 0, null: false
-    t.integer "use_count", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "hint"
     t.text "answer"
     t.text "answer_code"
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.text "hint"
+    t.integer "like_count", default: 0, null: false
+    t.string "title", limit: 50, null: false
+    t.datetime "updated_at", null: false
+    t.integer "use_count", default: 0, null: false
+    t.bigint "user_id", null: false
     t.index ["title"], name: "index_pre_codes_on_title"
     t.index ["user_id", "created_at"], name: "index_pre_codes_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_pre_codes_on_user_id"
@@ -147,19 +147,19 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_180431) do
   end
 
   create_table "quiz_questions", force: :cascade do |t|
-    t.bigint "quiz_id", null: false
-    t.bigint "quiz_section_id", null: false
-    t.text "question", null: false
     t.string "choice1", limit: 100, null: false
     t.string "choice2", limit: 100, null: false
     t.string "choice3", limit: 100, null: false
     t.string "choice4", limit: 100, null: false
     t.integer "correct_choice", null: false
-    t.text "explanation", null: false
-    t.integer "position", null: false
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.text "explanation", null: false
     t.integer "lock_version", default: 0, null: false
+    t.integer "position", null: false
+    t.text "question", null: false
+    t.bigint "quiz_id", null: false
+    t.bigint "quiz_section_id", null: false
+    t.datetime "updated_at", null: false
     t.index ["quiz_id"], name: "index_quiz_questions_on_quiz_id"
     t.index ["quiz_section_id", "position"], name: "index_quiz_questions_on_quiz_section_id_and_position"
     t.index ["quiz_section_id"], name: "index_quiz_questions_on_quiz_section_id"
@@ -169,13 +169,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_180431) do
   end
 
   create_table "quiz_sections", force: :cascade do |t|
-    t.bigint "quiz_id", null: false
+    t.bigint "book_section_id"
+    t.datetime "created_at", null: false
     t.string "heading", limit: 100, null: false
     t.boolean "is_free", default: false, null: false
     t.integer "position", null: false
-    t.datetime "created_at", null: false
+    t.bigint "quiz_id", null: false
     t.datetime "updated_at", null: false
-    t.bigint "book_section_id"
     t.index ["book_section_id"], name: "index_quiz_sections_on_book_section_id"
     t.index ["quiz_id", "position"], name: "index_quiz_sections_on_quiz_id_and_position"
     t.index ["quiz_id"], name: "index_quiz_sections_on_quiz_id"
@@ -183,10 +183,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_180431) do
   end
 
   create_table "quizzes", force: :cascade do |t|
-    t.string "title", limit: 100, null: false
+    t.datetime "created_at", null: false
     t.text "description", null: false
     t.integer "position", null: false
-    t.datetime "created_at", null: false
+    t.string "title", limit: 100, null: false
     t.datetime "updated_at", null: false
     t.index ["position"], name: "index_quizzes_on_position"
     t.check_constraint "\"position\" > 0 AND \"position\" <= 9999", name: "quizzes_position_range_chk"
@@ -194,23 +194,23 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_180431) do
   end
 
   create_table "solid_cache_entries", id: false, force: :cascade do |t|
-    t.binary "key", null: false
-    t.binary "value", null: false
-    t.datetime "created_at", null: false
-    t.bigint "key_hash", null: false
     t.integer "byte_size", null: false
+    t.datetime "created_at", null: false
+    t.binary "key", null: false
+    t.bigint "key_hash", null: false
+    t.binary "value", null: false
     t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
     t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
     t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 
   create_table "tags", force: :cascade do |t|
+    t.string "color", limit: 7
+    t.datetime "created_at", null: false
     t.string "name", limit: 30, null: false
     t.string "name_norm", limit: 60, null: false
     t.string "slug", limit: 80, null: false
-    t.string "color", limit: 7
     t.integer "taggings_count", default: 0, null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "zero_since"
     t.index ["name_norm"], name: "index_tags_on_name_norm", unique: true
@@ -221,11 +221,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_180431) do
   end
 
   create_table "used_codes", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "pre_code_id", null: false
-    t.datetime "used_at", null: false
     t.datetime "created_at", null: false
+    t.bigint "pre_code_id", null: false
     t.datetime "updated_at", null: false
+    t.datetime "used_at", null: false
+    t.bigint "user_id", null: false
     t.index ["pre_code_id", "created_at"], name: "index_used_codes_on_pre_code_id_and_created_at"
     t.index ["pre_code_id"], name: "index_used_codes_on_pre_code_id"
     t.index ["user_id", "pre_code_id"], name: "index_used_codes_on_user_id_and_pre_code_id"
@@ -233,32 +233,32 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_180431) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name", limit: 50, null: false
-    t.string "email", limit: 255
-    t.string "password_digest"
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
     t.boolean "admin", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "editor", default: false, null: false
-    t.datetime "banned_at"
     t.string "ban_reason"
+    t.datetime "banned_at"
+    t.datetime "created_at", null: false
+    t.boolean "editor", default: false, null: false
+    t.string "email", limit: 255
     t.datetime "last_login_at"
-    t.string "remember_digest"
+    t.string "name", limit: 50, null: false
+    t.string "password_digest"
     t.datetime "remember_created_at"
+    t.string "remember_digest"
+    t.datetime "reset_password_sent_at"
+    t.string "reset_password_token"
+    t.datetime "updated_at", null: false
     t.index "lower((email)::text)", name: "index_users_on_lower_email_unique", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token_unique", unique: true
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string "item_type", null: false
-    t.bigint "item_id", null: false
-    t.string "event", null: false
-    t.string "whodunnit"
-    t.text "object"
     t.datetime "created_at"
+    t.string "event", null: false
+    t.bigint "item_id", null: false
+    t.string "item_type", null: false
+    t.text "object"
     t.text "object_changes"
+    t.string "whodunnit"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 


### PR DESCRIPTION
### 目的
Books/Quiz 管理画面の使い勝手と整合性を改善し、見出し上限の不足・検索性の低さ・フォーム不整合を解消する。

### 変更点
- book_sections.heading の最大長を 50 → 100 に拡張する Migration を追加（既存データ影響なし）
- BookSections/QuizSections/QuizQuestions 一覧に Ransack 検索＋ページネーションを導入
- 既存のバリデーション・PaperTrail・スコープ・前後ナビは維持したまま、Ransack 許可メソッドのみ最小差分で追加
- Quiz 選択に応じて Section を絞る Stimulus（quiz_form）を新規実装し、フォームを完成版に差し替え
- ルーティングに `/admin/quiz_sections/options` を追加し、依存ドロップダウンのデータ供給を実装

### 動作確認
- 管理: BookSections/QuizSections/QuizQuestions でタイトル・見出し検索が機能し、ページネーションが表示される
- Quiz Questions フォームで Quiz を変更すると Section が該当分だけに置き換わる（既存選択も保持）
- book_sections.heading に 51〜100 文字が保存可能、101 文字はバリデーション/DB制約で弾かれる
- 既存のバリデーション/PaperTrail/前後ナビが動作していることを画面・モデルで確認