### PR TITLE
ActiveStorageをPersistent Diskに永続化: storage.ymlのproductionをENV参照化（RAIL…

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -23,3 +23,11 @@ test:
 local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
+
+# =======================
+# 本番（Render）環境
+# =======================
+production:
+  service: Disk
+  # Persistent Disk を /rails/storage にマウントし、環境変数で参照
+  root: <%= ENV.fetch("RAILS_STORAGE_ROOT", Rails.root.join("storage")) %>


### PR DESCRIPTION
## 目的
- ActiveStorage の保存先を Render の Persistent Disk に固定し、再デプロイ等で画像が消えないようにする。
- 本PRでは「画像永続化のみ」を適用し、Quillの表機能など他の変更は含めない。

## 変更点
- `config/storage.yml` の `production:` を ENV 参照に変更
  - `root: <%= ENV.fetch("RAILS_STORAGE_ROOT", Rails.root.join("storage")) %>`

## Render側の前提設定
- Disks → Add Disk → Mount: `/rails/storage`
- Environment Variable → `RAILS_STORAGE_ROOT=/rails/storage`
- その後、再デプロイ

## 動作確認（ローカル/本番）
- 管理画面からテキストのみ更新 → 保存される（更新日時が進む）
- 画像をアップロード→表示される
- Manual Redeploy 後も画像が残っている（永続化OK）

## 影響範囲
- ファイル保存パスのみ。アプリの挙動やDBスキーマには影響なし。
- 既存の画像（消えてしまった分）は復元不可。以後のアップロード分が永続化対象。

## 次フェーズ（別PR予定）
- Quill の表機能導入（`quill-better-table`）
- サニタイザの table 許可・見た目整え